### PR TITLE
Remove MinerU, Marker, EdgeQuake from benchmark

### DIFF
--- a/benchmark/compare_all.py
+++ b/benchmark/compare_all.py
@@ -64,8 +64,8 @@ ISOLATED_VENVS_DIR = BENCH_DIR / ".venvs"
 # (e.g. marker-pdf and mineru[all] each carry incompatible torch/torchvision).
 ISOLATED_VENVS_DIR = BENCH_DIR / ".venvs"
 
-# All known engines in preferred display order
-ALL_ENGINES = ["edgeparse", "opendataloader", "docling", "marker", "mineru", "pymupdf4llm", "markitdown", "edgequake"]
+# All known engines in preferred display order (EdgeQuake removed)
+ALL_ENGINES = ["edgeparse", "opendataloader", "docling", "pymupdf4llm", "markitdown"]
 
 # pip install commands for each engine
 INSTALL_COMMANDS = {

--- a/benchmark/src/engine_registry.py
+++ b/benchmark/src/engine_registry.py
@@ -35,11 +35,10 @@ ENGINE_META: Dict[str, tuple] = {
     "edgeparse":        ("EdgeParse",        None,                "Rust PDF engine (this repo)"),
     "opendataloader": ("OpenDataLoader", "opendataloader-pdf","Java/Python PDF engine"),
     "docling":        ("Docling",        "docling",           "IBM Research document parser"),
-    "marker":         ("Marker",         "marker-pdf",        "ML-based PDF-to-Markdown"),
-    "mineru":         ("MinerU",         "mineru[all]",       "OpenDataLab PDF extractor"),
+    # "marker":         ("Marker",         "marker-pdf",        "ML-based PDF-to-Markdown"),
+    # "mineru":         ("MinerU",         "mineru[all]",       "OpenDataLab PDF extractor"),
     "pymupdf4llm":    ("PyMuPDF4LLM",   "pymupdf4llm",       "PyMuPDF for LLM/RAG"),
     "markitdown":     ("MarkItDown",     "markitdown[all]",   "Microsoft multi-format converter"),
-    "edgequake":      ("EdgeQuake",      None,                "VLM-based PDF parser (gpt-4.1-nano)"),
 }
 
 # ── Auto-register external engines ───────────────────────────────────────────
@@ -55,11 +54,11 @@ def _try_register(name: str, module_name: str, version_label: str = "installed")
 
 _try_register("opendataloader", "pdf_parser_opendataloader", "published")
 _try_register("docling",        "pdf_parser_docling",        "installed")
-_try_register("marker",         "pdf_parser_marker",         "installed")
-_try_register("mineru",         "pdf_parser_mineru",         "installed")
+
+
 _try_register("pymupdf4llm",    "pdf_parser_pymupdf4llm",   "installed")
 _try_register("markitdown",     "pdf_parser_markitdown",     "installed")
-_try_register("edgequake",      "pdf_parser_edgequake",      "installed")
+
 
 
 def available_engines() -> list:

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -1,0 +1,116 @@
+# EdgeParse — Project Overview
+
+> **"Code is law"** — every statement here is traceable to a source file.
+
+EdgeParse is a high-performance PDF-to-structured-data extraction engine written in Rust.
+It converts raw PDF byte streams into semantically-rich, machine-readable output (JSON, Markdown, HTML, plain text) using a deterministic 20-stage processing pipeline.
+
+---
+
+## Repository Layout
+
+```
+edgepdf/
+├── Cargo.toml                          ← Workspace root: 5 crates
+│
+├── crates/
+│   ├── pdf-cos/                        ← Low-level PDF object model (fork of lopdf 0.39.0)
+│   ├── edgeparse-core/                 ← The extraction engine (all business logic)
+│   │   ├── src/
+│   │   │   ├── lib.rs                  ← Public API: convert()
+│   │   │   ├── api/                    ← Config, filter, batch
+│   │   │   ├── models/                 ← Type system: BoundingBox → ContentElement
+│   │   │   ├── pdf/                    ← PDF loading & chunk extraction
+│   │   │   ├── pipeline/               ← 20-stage orchestrator + stages
+│   │   │   ├── output/                 ← Renderers: JSON, MD, HTML, text
+│   │   │   ├── tagged/                 ← Tagged-PDF structure tree
+│   │   │   └── utils/                  ← XY-Cut, layout analysis, sanitizer
+│   │   └── tests/
+│   ├── edgeparse-cli/                  ← Binary: edgeparse <input> [opts]
+│   ├── edgeparse-python/               ← PyO3 extension: edgeparse.convert()
+│   └── edgeparse-node/                 ← NAPI-RS extension: edgeparse.convert()
+│
+├── sdks/
+│   ├── python/                         ← Python package (wraps edgeparse-python)
+│   └── node/                           ← Node.js package (wraps edgeparse-node)
+│
+├── benchmark/                          ← Accuracy benchmark suite (Python)
+├── benches/                            ← Rust micro-benchmarks (criterion)
+└── tests/                              ← Integration test fixtures
+```
+
+**Workspace definition:** [`Cargo.toml`](../Cargo.toml)
+
+---
+
+## Ten-Second Mental Model
+
+```
+                      ┌────────────────────────────────────────────────────────┐
+  PDF File            │                   edgeparse-core                        │
+  ─────────           │                                                          │
+   bytes ──▶ pdf-cos  │  chunk       pipeline        output                    │
+             (lopdf)  │  parser ──▶ orchestrator ──▶ renderers ──▶ String/File │
+                      │  (Stage 0)  (Stages 1–19)   (Stage 20)                 │
+                      └────────────────────────────────────────────────────────┘
+                                          │
+                              ┌───────────┼───────────┐
+                              │           │           │
+                           CLI        Python SDK   Node.js SDK
+```
+
+The engine is pure Rust and has **zero Python/Node runtime dependencies at parse time**.
+The Python and Node.js SDKs are thin FFI wrappers — all logic lives in `edgeparse-core`.
+
+---
+
+## Public Contracts
+
+| Layer | Entry point | Return type |
+|-------|------------|-------------|
+| Rust API | [`edgeparse_core::convert()`](../crates/edgeparse-core/src/lib.rs#L42) | `Result<PdfDocument, EdgePdfError>` |
+| CLI | [`edgeparse-cli/src/main.rs`](../crates/edgeparse-cli/src/main.rs) | Exit code + files on disk |
+| Python | [`edgeparse_core.convert()`](../crates/edgeparse-python/src/lib.rs#L31) | `str` |
+| Node.js | [`convert()`](../crates/edgeparse-node/src/lib.rs#L22) | `string` |
+
+---
+
+## Key Design Decisions
+
+| Decision | Rationale | Code location |
+|----------|-----------|---------------|
+| Single-pass chunk parser | Avoids multiple content-stream decodes | [`chunk_parser.rs`](../crates/edgeparse-core/src/pdf/chunk_parser.rs) |
+| Rayon parallel per-page | Pages are independent; saturates CPU cores | [`parallel.rs`](../crates/edgeparse-core/src/pipeline/parallel.rs) |
+| Mutable `PipelineState` | Avoids cloning large page vectors between stages | [`orchestrator.rs`](../crates/edgeparse-core/src/pipeline/orchestrator.rs) |
+| `ContentElement` enum | Single type models all abstraction levels (raw→semantic) | [`content.rs`](../crates/edgeparse-core/src/models/content.rs) |
+| pdf-cos (lopdf fork) | Custom encryption/CMaps without upstream release dependency | [`crates/pdf-cos/`](../crates/pdf-cos/) |
+| XY-Cut++ reading order | Handles multi-column layouts without ML dependency | [`xycut.rs`](../crates/edgeparse-core/src/utils/xycut.rs) |
+
+---
+
+## Error Architecture
+
+```
+EdgePdfError  (lib.rs)
+├── LoadError(String)          ← pdf::loader fails to open/decrypt
+├── PipelineError{stage, msg}  ← any stage returns Err
+├── OutputError(String)        ← renderer write failure
+├── IoError(std::io::Error)    ← file I/O (#[from])
+├── ConfigError(String)        ← invalid config values
+└── LopdfError(String)         ← pdf-cos object errors (#[from] lopdf::Error)
+```
+
+**Source:** [`crates/edgeparse-core/src/lib.rs#L124`](../crates/edgeparse-core/src/lib.rs#L124)
+
+---
+
+## Cross-Reference to Other Docs
+
+| Document | What you'll learn |
+|----------|------------------|
+| [01-architecture.md](01-architecture.md) | Crate dependency graph, module structure, threading model |
+| [02-pipeline.md](02-pipeline.md) | All 20 stages with inputs/outputs and code pointers |
+| [03-data-model.md](03-data-model.md) | Full type hierarchy from `BoundingBox` to `PdfDocument` |
+| [04-pdf-extraction.md](04-pdf-extraction.md) | Content stream parsing, font resolution, graphics state |
+| [05-output-formats.md](05-output-formats.md) | Renderers: JSON, Markdown, HTML, text |
+| [06-sdk-integration.md](06-sdk-integration.md) | CLI flags, Python API, Node.js API |

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -1,0 +1,301 @@
+# EdgeParse — System Architecture
+
+> All diagrams reflect actual source code. Every box maps to a real Rust module.
+
+---
+
+## 01 · Crate Dependency Graph
+
+```
+       ┌─────────────────┐
+       │   edgeparse-cli  │  (binary)
+       └────────┬────────┘
+                │ depends on
+       ┌────────▼────────────────────────────┐
+       │        edgeparse-core               │  (library)
+       │                                     │
+       │  api/  models/  pdf/  pipeline/     │
+       │  output/  tagged/  utils/           │
+       └────────┬────────────────────────────┘
+                │ depends on
+       ┌────────▼────────┐   ┌──────────────────────┐
+       │    pdf-cos       │   │  external crates      │
+       │  (lopdf 0.39.0  │   │  rayon, serde,        │
+       │   fork/rename)  │   │  clap, image,         │
+       └─────────────────┘   │  regex, tokio, etc.   │
+                             └──────────────────────┘
+
+       ┌──────────────────────┐    ┌──────────────────────┐
+       │  edgeparse-python    │    │   edgeparse-node     │
+       │  (PyO3 FFI wrapper)  │    │   (NAPI-RS wrapper)  │
+       └──────────┬───────────┘    └──────────┬───────────┘
+                  └──────────────────────────▼
+                              edgeparse-core
+```
+
+**Workspace root:** [`Cargo.toml`](../Cargo.toml)
+**pdf-cos alias:** declared as `lopdf = { package = "pdf-cos", path = "crates/pdf-cos" }` so all existing `use lopdf::…` code compiles unchanged.
+
+---
+
+## 02 · Module Map (edgeparse-core)
+
+```
+crates/edgeparse-core/src/
+│
+├── lib.rs                    ← Top-level convert() entry point
+│
+├── api/
+│   ├── mod.rs
+│   ├── config.rs             ← ProcessingConfig (24 fields), enums
+│   ├── filter.rs             ← FilterConfig — hidden text, off-page, tiny
+│   ├── config_loader.rs      ← Optional JSON config loading
+│   └── batch.rs              ← BatchResult, process_batch()
+│
+├── models/
+│   ├── mod.rs
+│   ├── bbox.rs               ← BoundingBox  (geometry primitive)
+│   ├── chunks.rs             ← TextChunk, ImageChunk, LineChunk, LineArtChunk
+│   ├── text.rs               ← TextLine, TextBlock, TextColumn
+│   ├── table.rs              ← TableBorder, TableBorderRow, TableBorderCell
+│   ├── list.rs               ← PDFList, PDFListItem
+│   ├── semantic.rs           ← SemanticParagraph, SemanticHeading, etc.
+│   ├── document.rs           ← PdfDocument (root output type)
+│   ├── content.rs            ← ContentElement enum (unified)
+│   └── enums.rs              ← SemanticType, TextFormat, TextType, ...
+│
+├── pdf/
+│   ├── mod.rs
+│   ├── loader.rs             ← load_pdf() → RawPdfDocument
+│   ├── chunk_parser.rs       ← Single-pass content stream walker → PageChunks
+│   ├── text_extractor.rs     ← Text-only extractor (legacy path, still used)
+│   ├── line_extractor.rs     ← Line/path geometry extraction
+│   ├── image_extractor.rs    ← XObject / inline image extraction
+│   ├── font.rs               ← Font resolution, CMap decoding, glyph → Unicode
+│   ├── graphics_state.rs     ← CTM, color state, text state stack
+│   ├── page_info.rs          ← PageInfo: MediaBox, CropBox, Rotation
+│   ├── encryption.rs         ← Password-based decryption
+│   ├── annotation_extractor.rs
+│   ├── annotation_enrichment.rs
+│   ├── bookmark_extractor.rs
+│   ├── hyperlink_extractor.rs
+│   ├── form_extractor.rs
+│   ├── metadata_writer.rs
+│   └── raster_table_ocr.rs   ← Image-based table border recovery
+│
+├── pipeline/
+│   ├── mod.rs
+│   ├── orchestrator.rs       ← run_pipeline() — sequences all 20 stages
+│   ├── parallel.rs           ← par_map_pages() / par_map_pages_indexed()
+│   ├── logging.rs
+│   ├── error_recovery.rs
+│   └── stages/
+│       ├── mod.rs
+│       ├── watermark_detector.rs
+│       ├── content_filter.rs
+│       ├── content_sanitizer.rs
+│       ├── table_detector.rs
+│       ├── table_content_assigner.rs
+│       ├── cluster_table_detector.rs
+│       ├── boxed_heading_promoter.rs
+│       ├── column_detector.rs
+│       ├── text_line_grouper.rs
+│       ├── text_block_grouper.rs
+│       ├── header_footer.rs
+│       ├── list_detector.rs
+│       ├── list_pass2.rs
+│       ├── paragraph_detector.rs
+│       ├── figure_detector.rs
+│       ├── heading_detector.rs
+│       ├── id_assignment.rs
+│       ├── caption_linker.rs
+│       ├── footnote_detector.rs
+│       ├── footnote_linker.rs
+│       ├── toc_detector.rs
+│       ├── cross_page_linker.rs
+│       ├── nesting_level.rs
+│       ├── reading_order.rs
+│       └── output_builder.rs
+│
+├── output/
+│   ├── mod.rs
+│   ├── json.rs               ← Canonical JSON format
+│   ├── legacy_json.rs        ← Legacy/compatibility JSON
+│   ├── markdown.rs           ← Markdown (with special-case handling)
+│   ├── html.rs               ← HTML5
+│   ├── text.rs               ← Plain text
+│   ├── csv.rs                ← CSV (tables)
+│   ├── docx.rs               ← DOCX (stub)
+│   └── toc_builder.rs        ← TOC extraction helper
+│
+├── tagged/
+│   ├── mod.rs
+│   ├── struct_tree.rs        ← extract_struct_tree(), build_mcid_map()
+│   └── processor.rs          ← TaggedProcessor
+│
+└── utils/
+    ├── mod.rs
+    ├── xycut.rs              ← XY-Cut++ reading order algorithm
+    ├── layout_analysis.rs    ← Column geometry analysis
+    ├── font_metrics_cache.rs
+    ├── image_dedup.rs
+    ├── language_detector.rs
+    ├── page_range.rs         ← parse_page_range(), filter_pages()
+    ├── sanitizer.rs          ← PII removal
+    ├── statistics.rs
+    ├── text_normalizer.rs
+    ├── xref_index.rs
+    └── diff.rs
+```
+
+---
+
+## 03 · Threading Model
+
+```
+                              Main thread
+                                  │
+                    ┌─────────────▼──────────────┐
+                    │   run_pipeline(state)        │
+                    │   orchestrator.rs            │
+                    └─────────────┬───────────────┘
+                                  │
+                 ┌────────────────┼────────────────┐
+                 │                │                │
+         PAGE-PARALLEL STAGES     │      CROSS-PAGE STAGES
+         (rayon thread pool)      │      (single-threaded)
+                 │                │                │
+    par_map_pages() calls         │   header_footer::detect_headers_footers()
+                                  │   heading_detector::detect_headings()
+    table_detector        ← CPU   │   cross_page_linker::link_cross_page_tables()
+    text_line_grouper     ← CPU   │   reading_order::sort_reading_order()
+    text_block_grouper    ← CPU   │   list_pass2::detect_common_prefix_lists_document()
+    list_detector         ← CPU   │   id_assignment::assign_ids()
+    paragraph_detector    ← CPU   │
+    figure_detector       ← CPU   │
+    content_sanitizer     ← CPU   │
+```
+
+**Key:** `par_map_pages` in [`parallel.rs`](../crates/edgeparse-core/src/pipeline/parallel.rs#L24) uses Rayon's work-stealing thread pool.
+Cross-page stages operate on `&mut state.pages` sequentially because they compare elements across page boundaries.
+
+---
+
+## 04 · Data Flow (End-to-End)
+
+```
+PDF File (bytes)
+    │
+    ▼ pdf::loader::load_pdf()         [loader.rs]
+RawPdfDocument
+  ├── document: lopdf::Document
+  └── metadata: PdfMetadata
+    │
+    ▼ pdf::page_info::extract_page_info()  [page_info.rs]
+Vec<PageInfo>  (MediaBox, CropBox, Rotation per page)
+    │
+    ▼ pdf::chunk_parser::extract_page_chunks()  [chunk_parser.rs]
+PageChunks (per page)
+  ├── text_chunks:    Vec<TextChunk>    (font run atoms)
+  ├── image_chunks:   Vec<ImageChunk>   (XObject / inline)
+  ├── line_chunks:    Vec<LineChunk>    (path geometry)
+  └── line_art_chunks: Vec<LineArtChunk> (compound paths)
+    │
+    ▼  Merge into ContentElement variants
+Vec<ContentElement>  per page  →  PipelineState.pages
+    │
+    ▼ pipeline::orchestrator::run_pipeline()  [orchestrator.rs]
+  Stage 0b ─ Page Range Filter
+  Stage 1b ─ Watermark Removal
+  Stage 2  ─ Content Filter (hidden, off-page, tiny, OCG)
+  Stage 2b ─ Replace U+FFFD
+  ...
+  Stage 18 ─ Reading Order (XY-Cut++)
+  Stage 19 ─ Content Sanitization
+                │
+                ▼
+PipelineState.pages  (semantic ContentElements)
+    │
+    ▼ Build PdfDocument                    [lib.rs#L103]
+PdfDocument
+  ├── file_name, number_of_pages, metadata
+  └── kids: Vec<ContentElement>  (all pages flattened, reading order)
+    │
+    ▼ output::{json,markdown,html,text}::to_*()
+String  (serialised output)
+```
+
+---
+
+## 05 · Memory Layout
+
+All page content lives as `Vec<ContentElement>` (a Rust enum — no heap-boxing per element).
+`PipelineState` holds a `Vec<Vec<ContentElement>>` — one inner Vec per page.
+Stages that work per-page use `std::mem::take` to avoid double-borrow violations:
+
+```rust
+// parallel.rs — par_map_pages pattern
+let results: Vec<PageContent> = std::mem::take(pages)
+    .into_par_iter()
+    .map(|page| op(page))
+    .collect();
+*pages = results;
+```
+
+**Source:** [`parallel.rs#L27`](../crates/edgeparse-core/src/pipeline/parallel.rs#L27)
+
+---
+
+## 06 · Configuration Surface
+
+`ProcessingConfig` has 24 fields — see full definition at [`config.rs`](../crates/edgeparse-core/src/api/config.rs):
+
+```
+ProcessingConfig
+├── output_dir         : Option<String>
+├── password           : Option<String>
+├── formats            : Vec<OutputFormat>  {Json,Text,Html,Pdf,Markdown,...}
+├── quiet              : bool
+├── filter_config      : FilterConfig       ← content safety
+├── sanitize           : bool               ← PII removal
+├── keep_line_breaks   : bool
+├── replace_invalid_chars : String          ← default " "
+├── use_struct_tree    : bool
+├── table_method       : TableMethod        {Default, Cluster}
+├── reading_order      : ReadingOrder       {Off, XyCut}
+├── markdown_page_separator : Option<String>
+├── text_page_separator     : Option<String>
+├── html_page_separator     : Option<String>
+├── image_output       : ImageOutput        {Off, Embedded, External}
+├── image_format       : ImageFormat        {Png, Jpeg}
+├── image_dir          : Option<String>
+├── pages              : Option<String>     ← "1,3,5-7"
+├── include_header_footer : bool
+├── hybrid             : HybridBackend      {Off, DoclingFast}
+├── hybrid_mode        : HybridMode         {Auto, Full}
+├── hybrid_url         : Option<String>
+├── hybrid_timeout     : u64                ← ms, default 30000
+└── hybrid_fallback    : bool
+```
+
+`FilterConfig` (content safety):
+```
+FilterConfig
+├── filter_hidden_text   : bool  (low contrast ratio)
+├── filter_out_of_page   : bool  (outside CropBox)
+├── filter_tiny_text     : bool  (below min height)
+└── filter_hidden_ocg    : bool  (invisible OCG layers)
+```
+**Source:** [`filter.rs`](../crates/edgeparse-core/src/api/filter.rs)
+
+---
+
+## Cross-Reference
+
+| Topic | Document |
+|-------|---------|
+| Full pipeline stage sequence | [02-pipeline.md](02-pipeline.md) |
+| Type hierarchy | [03-data-model.md](03-data-model.md) |
+| PDF chunk parsing internals | [04-pdf-extraction.md](04-pdf-extraction.md) |
+| Output renderers | [05-output-formats.md](05-output-formats.md) |
+| CLI / SDK APIs | [06-sdk-integration.md](06-sdk-integration.md) |

--- a/docs/02-pipeline.md
+++ b/docs/02-pipeline.md
@@ -1,0 +1,558 @@
+# EdgeParse — 20-Stage Processing Pipeline
+
+> Every stage listed here exists as a real function called in
+> [`orchestrator.rs`](../crates/edgeparse-core/src/pipeline/orchestrator.rs).
+> Stage numbers follow the orchestrator source comments.
+
+---
+
+## Pipeline Overview
+
+```
+       PDF bytes
+           │
+           ▼
+     ┌──────────────────────────────────────────────────────────────────┐
+     │  PRE-PIPELINE: PDF Loading & Chunk Extraction                    │
+     │                                                                  │
+     │  loader::load_pdf()          → RawPdfDocument                   │
+     │  page_info::extract_page_info() → Vec<PageInfo>                 │
+     │  chunk_parser::extract_page_chunks() → PageChunks per page      │
+     └──────────────────────────────────────────────────────────────────┘
+           │
+           ▼  Vec<ContentElement> per page  (text + image + line chunks)
+     ┌──────────────────────────────────────────────────────────────────┐
+     │  LAYER 1: Safety & Filtering                                     │
+     │                                                                  │
+     │  Stage 0b  Page Range Filtering      page_range::filter_pages() │
+     │  Stage 1b  Watermark Removal         watermark_detector         │
+     │  Stage 2   Content Filtering         content_filter             │
+     │  Stage 2b  Replace U+FFFD            replace_fffd_in_element()  │
+     └──────────────────────────────────────────────────────────────────┘
+           │
+           ▼  Cleaned TextChunk / Image / Line elements
+     ┌──────────────────────────────────────────────────────────────────┐
+     │  LAYER 2: Table Detection                                        │
+     │                                                                  │
+     │  Stage 3-4  Border Table Detection   table_detector             │
+     │  Stage 4b   Content → Table Cells    table_content_assigner     │
+     │  Stage 4b2  Filter Empty Tables      table_detector             │
+     │  Stage 4c   Boxed Heading Promoter   boxed_heading_promoter     │
+     │  Stage 4d   Pre-Cluster Table Release table_detector            │
+     └──────────────────────────────────────────────────────────────────┘
+           │
+           ▼  TableBorder elements + free TextChunks
+     ┌──────────────────────────────────────────────────────────────────┐
+     │  LAYER 3: Grouping                                               │
+     │                                                                  │
+     │  Stage 5b   Column Detection         column_detector            │
+     │  Stage 6    TextChunk → TextLine     text_line_grouper          │
+     │  Stage 6b   Re-run Column Detection  column_detector            │
+     │  Stage 6.5  List Detection Pass 1    list_detector              │
+     │  Stage 7    TextLine → TextBlock     text_block_grouper         │
+     │  Stage 7b   Cluster Table Detection  cluster_table_detector     │
+     │  Stage 7b2  Suspicious Table Filter  table_detector             │
+     └──────────────────────────────────────────────────────────────────┘
+           │
+           ▼  TextBlock / TextLine / TableBorder / List
+     ┌──────────────────────────────────────────────────────────────────┐
+     │  LAYER 4: Semantic Classification                                │
+     │                                                                  │
+     │  Stage 8    Header/Footer Detection  header_footer (cross-page) │
+     │  Stage 9    List Detection Pass 1    list_detector              │
+     │  Stage 10   Paragraph Detection      paragraph_detector         │
+     │  Stage 10b  Figure Detection         figure_detector            │
+     │  Stage 12   Heading Detection        heading_detector           │
+     └──────────────────────────────────────────────────────────────────┘
+           │
+           ▼  Heading / Paragraph / Figure / List / Table / HeaderFooter
+     ┌──────────────────────────────────────────────────────────────────┐
+     │  LAYER 5: Linking & Ordering                                     │
+     │                                                                  │
+     │  Stage 18-pre  Reading Order (pre-pass)  reading_order          │
+     │  Stage 11      List Detection Pass 2     list_pass2             │
+     │  Stage 11b     Common-prefix Lists       list_pass2             │
+     │  Stage 13      ID Assignment             id_assignment          │
+     │  Stage 14      Caption Linking           caption_linker         │
+     │  Stage 14b     Footnote Detection        footnote_detector      │
+     │  Stage 14c     TOC Detection             toc_detector           │
+     │  Stage 15      Cross-Page Table Linking  cross_page_linker      │
+     │  Stage 17      Nesting Level Assignment  nesting_level          │
+     │  Stage 18      Final Reading Order       reading_order          │
+     │  Stage 19      Content Sanitization      content_sanitizer      │
+     └──────────────────────────────────────────────────────────────────┘
+           │
+           ▼  PipelineState.pages (fully classified, ordered)
+     ┌──────────────────────────────────────────────────────────────────┐
+     │  POST-PIPELINE: PdfDocument Assembly  (lib.rs#L103)             │
+     └──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Stage-by-Stage Reference
+
+### Stage 0b — Page Range Filtering
+
+**Source:** [`utils/page_range.rs`](../crates/edgeparse-core/src/utils/page_range.rs)
+**Called from:** [`orchestrator.rs`](../crates/edgeparse-core/src/pipeline/orchestrator.rs) (line ~140)
+
+```
+Input:  config.pages = Some("1,3,5-7")
+Action: parse_page_range() → BTreeSet<usize>
+        filter_pages(pages, &selected) → keep only selected pages
+Output: state.pages shrunk to selected pages
+```
+
+**Trigger:** Only runs when `config.pages` is `Some`. Supports comma-separated numbers and ranges: `"1,3-5,7"`.
+
+---
+
+### Stage 1b — Watermark Removal
+
+**Source:** [`pipeline/stages/watermark_detector.rs`](../crates/edgeparse-core/src/pipeline/stages/watermark_detector.rs)
+**Parallelism:** Sequential (uses `&mut state.pages` across all pages)
+
+```
+Input:  Vec<ContentElement>  (all page elements)
+Action: Detect repeated or low-confidence text across pages
+        Mark or remove watermark candidates
+Output: Same Vec with watermark elements removed/ignored
+```
+
+Watermarks typically appear as: large text at center, very low contrast, or repeated identically across all pages.
+
+---
+
+### Stage 2 — Content Filtering
+
+**Source:** [`pipeline/stages/content_filter.rs`](../crates/edgeparse-core/src/pipeline/stages/content_filter.rs)
+**Parallelism:** `par_map_pages_indexed` (one filter run per page, parallel)
+**Config:** [`api/filter.rs`](../crates/edgeparse-core/src/api/filter.rs)
+
+```
+FilterConfig flags applied:
+  filter_hidden_text  → drop chunks where contrast_ratio < threshold
+  filter_out_of_page  → drop chunks outside CropBox
+  filter_tiny_text    → drop chunks below minimum height
+  filter_hidden_ocg   → drop chunks where ocg_visible == false
+```
+
+Page geometry (`CropBox`) is provided by `PageInfo` resolved via `state.page_info.get(page_idx)`.
+
+---
+
+### Stage 2b — Replace U+FFFD
+
+**Source:** [`orchestrator.rs` — `replace_fffd_in_element()`](../crates/edgeparse-core/src/pipeline/orchestrator.rs)
+**Parallelism:** `par_map_pages`
+
+Replaces Unicode replacement characters (`\u{FFFD}`) in `TextChunk.value` with `config.replace_invalid_chars` (default: `" "`). Only acts on `ContentElement::TextChunk` variants (other types don't exist yet at this stage).
+
+---
+
+### Stages 3–4 — Border Table Detection
+
+**Source:** [`pipeline/stages/table_detector.rs`](../crates/edgeparse-core/src/pipeline/stages/table_detector.rs)
+**Parallelism:** `par_map_pages`
+
+```
+Input:  Vec<ContentElement>  containing LineChunk elements
+Action: Group collinear horizontal/vertical line segments into grid cells
+        Build TableBorder{x_coordinates, y_coordinates, rows[cells]}
+Output: Vec<ContentElement>  with LineChunk → TableBorder promotions
+```
+
+**Algorithm sketch:**
+```
+1. Collect all LineChunk elements
+2. Cluster horizontal lines by Y-coordinate (± epsilon)
+3. Cluster vertical lines by X-coordinate (± epsilon)
+4. Build grid from intersections → (N rows × M cols)
+5. Create TableBorder with x_coordinates, y_coordinates
+6. Remove the constituent LineChunks from page
+```
+
+**Key data type:** [`models/table.rs — TableBorder`](../crates/edgeparse-core/src/models/table.rs)
+
+---
+
+### Stage 4b — Content Assignment to Table Cells
+
+**Source:** [`pipeline/stages/table_content_assigner.rs`](../crates/edgeparse-core/src/pipeline/stages/table_content_assigner.rs)
+**Parallelism:** `par_map_pages`
+
+```
+Input:  Page with TableBorder + free TextChunk/Image elements
+Action: For each TableBorder, for each cell:
+          compute intersection(chunk.bbox, cell.bbox) ≥ MIN_CELL_CONTENT_INTERSECTION_PERCENT
+          assign matching chunks to cell.text_chunks
+Output: TableBorder.rows[i].cells[j].text_chunks populated
+        Assigned elements removed from free pool
+```
+
+**Constant:** `MIN_CELL_CONTENT_INTERSECTION_PERCENT = 0.01` in [`models/table.rs`](../crates/edgeparse-core/src/models/table.rs#L14)
+
+---
+
+### Stage 4b2 — Filter Empty Tables (Chart Grid FPs)
+
+**Source:** [`table_detector::filter_empty_tables()`](../crates/edgeparse-core/src/pipeline/stages/table_detector.rs)
+
+Removes `TableBorder` elements where most cells are empty — these are typically chart grid lines rendered as bordered rectangles, not actual data tables.
+
+---
+
+### Stage 4c — Boxed Heading Promoter
+
+**Source:** [`pipeline/stages/boxed_heading_promoter.rs`](../crates/edgeparse-core/src/pipeline/stages/boxed_heading_promoter.rs)
+**Parallelism:** `par_map_pages`
+
+Single-cell tables containing short heading-like text are dissolved back into free `TextChunk` elements so `heading_detector` can classify them properly.
+
+```
+TableBorder(1 row × 1 col, short text) → TextChunk (released)
+```
+
+---
+
+### Stage 4d — Pre-Cluster Table Release
+
+**Source:** [`table_detector::release_pre_cluster_tables()`](../crates/edgeparse-core/src/pipeline/stages/table_detector.rs)
+
+Releases page-wide single-cell pseudo-tables (tables that span the full width of a page and likely result from layout artefacts) back into the free text flow before the cluster detector runs.
+
+---
+
+### Stage 5b — Column Detection
+
+**Source:** [`pipeline/stages/column_detector.rs`](../crates/edgeparse-core/src/pipeline/stages/column_detector.rs)
+**Parallelism:** Operates on `&mut state.pages`, returns `Vec<Option<ColumnLayout>>`
+
+```
+Input:  Vec<ContentElement> per page
+Action: Analyse X-coordinate distribution of elements
+        Detect vertical gap zones → column boundaries
+Output: ColumnLayout per page (passed to Stage 6)
+```
+
+Column layouts are used by `text_line_grouper` to prevent grouping chunks across column boundaries.
+
+---
+
+### Stage 6 — TextChunk → TextLine Grouping
+
+**Source:** [`pipeline/stages/text_line_grouper.rs`](../crates/edgeparse-core/src/pipeline/stages/text_line_grouper.rs)
+**Parallelism:** `par_map_pages_indexed`
+
+```
+Input:  Vec<ContentElement::TextChunk>
+Action: Group chunks that share the same baseline (± slant tolerance)
+        Within column boundaries
+        Insert space between chunks when gap > fontSize * 0.17
+Output: Vec<ContentElement::TextLine>
+```
+
+**Key type:** [`models/text.rs — TextLine`](../crates/edgeparse-core/src/models/text.rs)
+
+`TextLine.value()` reconstructs text by calling `needs_space(prev, curr)` to re-insert word spaces from bounding box gaps.
+
+---
+
+### Stage 6b — Re-run Column Detection on TextLines
+
+Second pass of column detection, now operating on formed `TextLine` elements for more stable geometry.
+
+---
+
+### Stage 6.5 — List Detection Pass 1 (TextLine Level)
+
+**Source:** [`pipeline/stages/list_detector.rs`](../crates/edgeparse-core/src/pipeline/stages/list_detector.rs)
+**Parallelism:** `par_map_pages`
+
+Detects list patterns at the `TextLine` level **before** block grouping. Catches bibliography entries (`[N]` bracket notation) and other list patterns that might be merged by Stage 7.
+
+---
+
+### Stage 7 — TextLine → TextBlock Grouping
+
+**Source:** [`pipeline/stages/text_block_grouper.rs`](../crates/edgeparse-core/src/pipeline/stages/text_block_grouper.rs)
+**Parallelism:** `par_map_pages`
+
+```
+Input:  Vec<ContentElement::TextLine>
+Action: Group consecutive TextLines that:
+        - share similar X-extent (left margin, right margin)
+        - have consistent line spacing
+        - belong to the same column
+Output: Vec<ContentElement::TextBlock>
+```
+
+**Key type:** [`models/text.rs — TextBlock`](../crates/edgeparse-core/src/models/text.rs)
+
+---
+
+### Stage 7b — Cluster (Borderless) Table Detection
+
+**Source:** [`pipeline/stages/cluster_table_detector.rs`](../crates/edgeparse-core/src/pipeline/stages/cluster_table_detector.rs)
+**Parallelism:** `par_map_pages`
+
+Detects tables that have **no visible borders** by clustering `TextBlock` elements with regular X/Y spacing patterns into a `TableBorder` grid. Only active when `config.table_method == TableMethod::Cluster`.
+
+---
+
+### Stage 7b2 — Suspicious Table Filter
+
+Rejects table-shaped layout artefacts from both border and cluster detectors, releasing their text back into the page flow.
+
+---
+
+### Stage 8 — Header / Footer Detection
+
+**Source:** [`pipeline/stages/header_footer.rs`](../crates/edgeparse-core/src/pipeline/stages/header_footer.rs)
+**Parallelism:** Sequential (cross-page comparison)
+
+```
+Input:  All pages + median page_height
+Action: Elements in top/bottom N% of page height that repeat across pages →
+        classify as Header or Footer
+Output: ContentElement::TextBlock → ContentElement::HeaderFooter
+```
+
+Uses `page_height` (median from `state.page_info`) for threshold calculation.
+
+---
+
+### Stage 9 — List Detection Pass 1 (Block Level)
+
+Second application of `list_detector::detect_lists`. Catches numbered list patterns in `TextBlock` elements that the block grouper may have split.
+
+---
+
+### Stage 10 — Paragraph Detection
+
+**Source:** [`pipeline/stages/paragraph_detector.rs`](../crates/edgeparse-core/src/pipeline/stages/paragraph_detector.rs)
+**Parallelism:** `par_map_pages`
+
+```
+Input:  TextBlock elements
+Action: Classify TextBlock → SemanticParagraph
+        Assign indentation level
+        Set enclosed_top / enclosed_bottom flags
+Output: ContentElement::Paragraph
+```
+
+**Key type:** [`models/semantic.rs — SemanticParagraph`](../crates/edgeparse-core/src/models/semantic.rs#L89)
+
+---
+
+### Stage 10b — Figure Detection
+
+**Source:** [`pipeline/stages/figure_detector.rs`](../crates/edgeparse-core/src/pipeline/stages/figure_detector.rs)
+**Parallelism:** `par_map_pages`
+
+```
+Input:  Image and LineArt elements
+Action: Group nearby ImageChunk/LineArtChunk into SemanticFigure
+Output: ContentElement::Figure
+```
+
+---
+
+### Stage 12 — Heading Detection
+
+**Source:** [`pipeline/stages/heading_detector.rs`](../crates/edgeparse-core/src/pipeline/stages/heading_detector.rs)
+**Parallelism:** Sequential (uses `mcid_map` for tagged PDFs, cross-page font analysis)
+
+```
+Input:  SemanticParagraph elements + optional McidMap
+Signals used:
+  A. Structure tree tag (McidMap): H/H1-H6 → direct classification
+  B. Font size relative to body text (dominant page font)
+  C. Font weight (bold) / italic angle
+  D. Location on page (near top = more likely heading)
+  E. Text length (short, no terminal punctuation)
+  F. Numeric prefix pattern ("1.2.3 Section Title")
+Output: ContentElement::Heading or ContentElement::NumberHeading
+        with heading_level: Option<u32>  (1-6)
+```
+
+**McidMap key:** `(page_number: u32, mcid: i64)` → `McidTagInfo{role, heading_level, struct_type}`
+**Source:** [`tagged/struct_tree.rs`](../crates/edgeparse-core/src/tagged/struct_tree.rs)
+
+---
+
+### Stage 18-pre — Reading Order Pre-pass
+
+First application of XY-Cut++ sorting — runs before List Pass 2 so elements are in correct reading order for sequential list detection.
+
+**Source:** [`pipeline/stages/reading_order.rs`](../crates/edgeparse-core/src/pipeline/stages/reading_order.rs)
+**Algorithm:** [`utils/xycut.rs`](../crates/edgeparse-core/src/utils/xycut.rs)
+
+---
+
+### Stage 11 — List Detection Pass 2 (Paragraph Level)
+
+**Source:** [`pipeline/stages/list_pass2.rs`](../crates/edgeparse-core/src/pipeline/stages/list_pass2.rs)
+**Parallelism:** `par_map_pages`
+
+Detects list patterns in classified `Paragraph` elements. Works on body text that contains bullet indicators, dash-prefixes, or numbered items.
+
+---
+
+### Stage 11b — Document-Level Common-Prefix Lists
+
+**Source:** [`list_pass2::detect_common_prefix_lists_document()`](../crates/edgeparse-core/src/pipeline/stages/list_pass2.rs)
+**Parallelism:** Sequential (operates across all pages)
+
+Identifies patterns like "Figure N …" or "Table N …" that repeat across the document and promotes them to `List` elements.
+
+---
+
+### Stage 13 — ID Assignment
+
+**Source:** [`pipeline/stages/id_assignment.rs`](../crates/edgeparse-core/src/pipeline/stages/id_assignment.rs)
+**Parallelism:** Sequential (global counter across all pages)
+
+Assigns a monotonically increasing `index: u32` to every `ContentElement`. Used by renderers and the cross-page linker.
+
+```
+Input:  state.pages — unindexed elements
+Action: Traverse all pages in order, call elem.set_index(counter++)
+Output: All elements have unique index values
+```
+
+---
+
+### Stage 14 — Caption Linking
+
+**Source:** [`pipeline/stages/caption_linker.rs`](../crates/edgeparse-core/src/pipeline/stages/caption_linker.rs)
+
+Links `Caption` elements to the nearest preceding `Figure` or `TableBorder` using spatial proximity and text prefix patterns ("Figure N", "Table N", etc.).
+
+Sets `SemanticCaption.linked_content_id` to the index of the linked element.
+
+---
+
+### Stage 14b — Footnote Detection
+
+**Source:** [`pipeline/stages/footnote_detector.rs`](../crates/edgeparse-core/src/pipeline/stages/footnote_detector.rs)
+
+Detects footnotes by:
+- Position at bottom of page
+- Small font size relative to body text
+- Numeric or symbolic prefix (1, *, †)
+
+---
+
+### Stage 14c — TOC Detection
+
+**Source:** [`pipeline/stages/toc_detector.rs`](../crates/edgeparse-core/src/pipeline/stages/toc_detector.rs)
+
+Detects Table of Contents sections using leader dot patterns, right-aligned page numbers, and section-number prefixes. Promotes matching elements to `SemanticType::TableOfContent`.
+
+---
+
+### Stage 15 — Cross-Page Table Linking
+
+**Source:** [`pipeline/stages/cross_page_linker.rs`](../crates/edgeparse-core/src/pipeline/stages/cross_page_linker.rs)
+**Parallelism:** Sequential
+
+Links `TableBorder` elements that span across page boundaries. Sets `TableBorder.previous_table` / `next_table` Box pointers. `BoundingBox.last_page_number` is updated to reflect the true extent.
+
+---
+
+### Stage 17 — Nesting Level Assignment
+
+**Source:** [`pipeline/stages/nesting_level.rs`](../crates/edgeparse-core/src/pipeline/stages/nesting_level.rs)
+
+Assigns `level: Option<String>` to each element based on its position in the semantic hierarchy (heading level, list nesting, etc.).
+
+---
+
+### Stage 18 — Final Reading Order Sorting
+
+**Source:** [`pipeline/stages/reading_order.rs`](../crates/edgeparse-core/src/pipeline/stages/reading_order.rs)
+**Algorithm:** [`utils/xycut.rs — xycut_sort()`](../crates/edgeparse-core/src/utils/xycut.rs#L24)
+
+```
+XY-Cut++ Algorithm:
+1. Find largest horizontal gap → candidate split_y
+2. Find largest vertical gap  → candidate split_x
+3. Prefer vertical (column) split when:
+   - Both gaps exist AND
+   - ≥ 2 elements on each side of vertical gap AND
+   - < 55% of elements span the full width (not full-width headings)
+4. Split by whichever wins
+5. Recurse on each partition
+6. If no split found: sort by quantized Y bucket (4 pt) then left_x
+```
+
+The 4-point Y-bucket prevents column-order reversal when elements in adjacent columns have slightly different Y coordinates due to PDF rounding.
+
+---
+
+### Stage 19 — Content Sanitization
+
+**Source:** [`pipeline/stages/content_sanitizer.rs`](../crates/edgeparse-core/src/pipeline/stages/content_sanitizer.rs)
+**Config:** `config.sanitize: bool`
+
+When `sanitize = true`, applies PII removal patterns (email addresses, phone numbers, SSNs, etc.) using regex-based replacement.
+
+**Source regexes:** [`utils/sanitizer.rs`](../crates/edgeparse-core/src/utils/sanitizer.rs)
+
+---
+
+## Execution Timeline Visualisation
+
+```
+Time ──────────────────────────────────────────────────────────────▶
+
+Stage 0b   [─]  (filter by page range — very fast)
+Stage 1b   [─────]  (scalar pass, cross-page)
+Stage 2    [══════════════]  (parallel, per page)
+Stage 2b   [══════]  (parallel, per page)
+Stage 3-4  [══════════════════]  (parallel, table geometry)
+Stage 4b   [══════════════]  (parallel)
+Stage 4b2  [══════]  (parallel)
+Stage 4c   [══════]  (parallel)
+Stage 4d   [══════]  (parallel)
+Stage 5b   [──────────]  (scalar, layout analysis)
+Stage 6    [══════════════════]  (parallel, line grouping)
+Stage 6b   [──────────]  (scalar)
+Stage 6.5  [══════════]  (parallel)
+Stage 7    [══════════════════]  (parallel, block grouping)
+Stage 7b   [══════════════]  (parallel, cluster tables)
+Stage 7b2  [══════]  (parallel)
+Stage 8    [──────────]  (scalar, cross-page)
+Stage 9    [══════════]  (parallel)
+Stage 10   [══════════════]  (parallel)
+Stage 10b  [══════]  (parallel)
+Stage 12   [──────────────]  (scalar, cross-page+tagged)
+Stage 18p  [──────────]  (scalar, pre-pass sort)
+Stage 11   [══════════]  (parallel)
+Stage 11b  [──────]  (scalar)
+Stage 13   [──────]  (scalar, global counter)
+Stage 14   [──────]  (scalar)
+Stage 14b  [══════]  (parallel)
+Stage 14c  [══════]  (parallel)
+Stage 15   [──────]  (scalar, cross-page)
+Stage 17   [══════]  (parallel)
+Stage 18   [──────────]  (scalar, final sort)
+Stage 19   [══════════]  (parallel, optional)
+
+══ = par_map_pages (Rayon parallel)
+── = sequential (cross-page or ordering constraint)
+```
+
+---
+
+## Cross-Reference
+
+| Topic | Document |
+|-------|---------|
+| Architecture & modules | [01-architecture.md](01-architecture.md) |
+| Data types used in stages | [03-data-model.md](03-data-model.md) |
+| PDF chunk extraction (pre-pipeline) | [04-pdf-extraction.md](04-pdf-extraction.md) |
+| Reading order (XY-Cut++) detail | [03-data-model.md#xycut](03-data-model.md) |
+| Output after pipeline | [05-output-formats.md](05-output-formats.md) |

--- a/docs/03-data-model.md
+++ b/docs/03-data-model.md
@@ -1,0 +1,522 @@
+# EdgeParse — Data Model
+
+> All types listed here are defined in `crates/edgeparse-core/src/models/`.
+> Every field shown maps to a real Rust struct field.
+
+---
+
+## 01 · Type Hierarchy
+
+```
+BoundingBox                          ← geometry primitive
+    │
+    ├── TextChunk                    ← atomic font run
+    ├── ImageChunk                   ← raster/vector image position
+    ├── LineChunk                    ← path segment (line/rect)
+    └── LineArtChunk                 ← compound path (bullet, border)
+             │
+             │  Stage 6: text_line_grouper
+             ▼
+           TextLine                  ← baseline-aligned chunk group
+             │
+             │  Stage 7: text_block_grouper
+             ▼
+           TextBlock                 ← paragraph-like text region
+             │
+             │  Stage 10: paragraph_detector
+             ▼
+       SemanticTextNode              ← base for all semantic types
+         ├── SemanticParagraph
+         ├── SemanticHeading         ← heading_level: Option<u32>
+         │     └── SemanticNumberHeading
+         └── SemanticCaption
+             │
+             │ Lateral types (parallel to SemanticTextNode)
+             ├── PDFList / PDFListItem
+             ├── TableBorder / TableBorderRow / TableBorderCell
+             ├── SemanticTable
+             ├── SemanticFigure
+             ├── SemanticHeaderOrFooter
+             ├── SemanticFormula
+             └── SemanticPicture
+                         │
+                         │  Wrapped by
+                         ▼
+                   ContentElement    ← unified page element enum
+                         │
+                         │  Collected into
+                         ▼
+                    PdfDocument.kids  ← final output
+```
+
+---
+
+## 02 · BoundingBox
+
+**Source:** [`models/bbox.rs`](../crates/edgeparse-core/src/models/bbox.rs)
+
+```
+BoundingBox {
+    page_number:      Option<u32>   // 1-based; None = page-agnostic
+    last_page_number: Option<u32>   // last page for cross-page elements
+    left_x:           f64           // left edge in PDF user units (points)
+    bottom_y:         f64           // bottom edge
+    right_x:          f64           // right edge
+    top_y:            f64           // top edge
+}
+```
+
+**Coordinate system:**
+
+```
+   (0,0) ─────────────────── (width, 0)
+     │   PDF user space           │
+     │   72 pt = 1 inch           │
+     │   origin: bottom-left      │
+     │                            │
+  (0, height) ──────── (width, height)   ← top-left in visual terms
+
+  ┌─────────────────── right_x
+  │  (left_x, top_y) ─────┐
+  │  │                    │
+  │  │   Element          │
+  │  │                    │
+  │  └── (left_x, bottom_y)
+  ▼
+  bottom_y
+```
+
+**Key methods:**
+
+| Method | Formula |
+|--------|---------|
+| `width()` | `right_x - left_x` |
+| `height()` | `top_y - bottom_y` |
+| `area()` | `width() × height()` |
+| `center_x()` | `(left_x + right_x) / 2` |
+| `center_y()` | `(bottom_y + top_y) / 2` |
+| `union(other)` | min left/bottom, max right/top |
+| `intersects(other)` | overlap test with epsilon |
+| `is_empty()` | width ≤ ε OR height ≤ ε |
+
+---
+
+## 03 · Chunk Types
+
+**Source:** [`models/chunks.rs`](../crates/edgeparse-core/src/models/chunks.rs)
+
+### TextChunk — Atomic font run
+
+```
+TextChunk {
+    value:          String          // decoded Unicode text
+    bbox:           BoundingBox
+    font_name:      String          // base font name, e.g. "Helvetica"
+    font_size:      f64             // effective size in points (post-CTM)
+    font_weight:    f64             // 100.0–900.0
+    italic_angle:   f64             // from font descriptor
+    font_color:     String          // "#RRGGBB"
+    contrast_ratio: f64             // 1.0–21.0 (WCAG contrast)
+    symbol_ends:    Vec<f64>        // X position of each glyph end
+    text_format:    TextFormat      // Normal | Superscript | Subscript
+    text_type:      TextType        // Regular | Math | Code | ...
+    pdf_layer:      PdfLayer        // Main | Form | Annotation
+    ocg_visible:    bool            // OCG (Optional Content Group) visibility
+    index:          Option<usize>
+    page_number:    Option<u32>
+    level:          Option<String>
+    mcid:           Option<i64>     // structure tree marker ID
+}
+```
+
+`symbol_ends` enables character-level bounding box queries:
+```
+symbol_start_coordinate(idx) → symbol_ends[idx-1] or bbox.left_x
+symbol_end_coordinate(idx)   → symbol_ends[idx]   or bbox.right_x
+```
+
+### ImageChunk
+
+```
+ImageChunk {
+    bbox:   BoundingBox
+    index:  Option<u32>
+    level:  Option<String>
+}
+```
+
+Pixel data is extracted lazily at output time; the chunk carries only position.
+
+### LineChunk — Path segment
+
+```
+LineChunk {
+    bbox:               BoundingBox
+    index:              Option<u32>
+    level:              Option<String>
+    start:              Vertex { x: f64, y: f64 }
+    end:                Vertex { x: f64, y: f64 }
+    width:              f64             // stroke width (points)
+    is_horizontal_line: bool
+    is_vertical_line:   bool
+    is_square:          bool
+}
+```
+
+Used by `table_detector` (Stages 3-4) to discover grid structures.
+
+### LineArtChunk — Complex vector graphic
+
+```
+LineArtChunk {
+    bbox:        BoundingBox
+    index:       Option<u32>
+    level:       Option<String>
+    line_chunks: Vec<LineChunk>   // component segments
+}
+```
+
+Produced when a path has ≥ 3 segments or non-orthogonal geometry.
+
+---
+
+## 04 · Text Grouping Types
+
+**Source:** [`models/text.rs`](../crates/edgeparse-core/src/models/text.rs)
+
+### TextLine
+
+```
+TextLine {
+    bbox:                      BoundingBox
+    index:                     Option<u32>
+    level:                     Option<String>
+    font_size:                 f64           // dominant font size
+    base_line:                 f64           // Y of text baseline
+    slant_degree:              f64
+    is_hidden_text:            bool
+    text_chunks:               Vec<TextChunk>
+    is_line_start:             bool          // begins paragraph
+    is_line_end:               bool          // ends paragraph
+    is_list_line:              bool
+    connected_line_art_label:  Option<LineArtChunk>  // bullet marker
+}
+```
+
+`TextLine.value()` reconstructs text with word-space inference:
+```
+needs_space(prev, curr):
+  gap = curr.bbox.left_x - prev.bbox.right_x
+  return gap > prev.font_size * TEXT_LINE_SPACE_RATIO  (0.17)
+```
+
+### TextBlock
+
+```
+TextBlock {
+    bbox:        BoundingBox
+    index:       Option<u32>
+    level:       Option<String>
+    text_lines:  Vec<TextLine>
+    ...          (alignment, column, font aggregates)
+}
+```
+
+### TextColumn
+
+```
+TextColumn {
+    text_blocks: Vec<TextBlock>
+}
+```
+
+`SemanticTextNode.value()` concatenates columns with `"\n"` separator.
+
+---
+
+## 05 · Semantic Node Hierarchy
+
+**Source:** [`models/semantic.rs`](../crates/edgeparse-core/src/models/semantic.rs)
+
+### SemanticTextNode (base)
+
+```
+SemanticTextNode {
+    bbox:                  BoundingBox
+    index:                 Option<u32>
+    level:                 Option<String>
+    semantic_type:         SemanticType     ← see §08 below
+    correct_semantic_score:Option<f64>      // classifier confidence
+    columns:               Vec<TextColumn>
+    font_weight:           Option<f64>
+    font_size:             Option<f64>
+    text_color:            Option<Vec<f64>> // [R,G,B] or [K] or [C,M,Y,K]
+    italic_angle:          Option<f64>
+    font_name:             Option<String>
+    text_format:           Option<TextFormat>
+    max_font_size:         Option<f64>
+    background_color:      Option<Vec<f64>>
+    is_hidden_text:        bool
+}
+```
+
+### Derived types
+
+```
+SemanticParagraph {
+    base:          SemanticTextNode
+    enclosed_top:  bool                // boxed at top
+    enclosed_bottom: bool              // boxed at bottom
+    indentation:   i32
+}
+
+SemanticHeading {
+    base:          SemanticParagraph
+    heading_level: Option<u32>         // 1-6; None until Stage 12
+}
+
+SemanticNumberHeading {
+    base:          SemanticHeading     // "1.2.3 Title"
+}
+
+SemanticCaption {
+    base:             SemanticTextNode
+    linked_content_id: Option<u64>    // index of linked Figure/Table
+}
+
+SemanticHeaderOrFooter {
+    bbox:          BoundingBox
+    index:         Option<u32>
+    level:         Option<String>
+    semantic_type: SemanticType        // Header or Footer
+    contents:      Vec<ContentElement>
+}
+
+SemanticFigure {
+    bbox:          BoundingBox
+    index:         Option<u32>
+    level:         Option<String>
+    semantic_type: SemanticType
+    images:        Vec<ImageChunk>
+    line_arts:     Vec<LineArtChunk>
+}
+
+SemanticTable {
+    bbox:         BoundingBox
+    index:        Option<u32>
+    level:        Option<String>
+    semantic_type:SemanticType
+    table_border: TableBorder
+}
+
+SemanticFormula {
+    bbox:  BoundingBox
+    index: Option<u32>
+    level: Option<String>
+    latex: String
+}
+
+SemanticPicture {
+    bbox:        BoundingBox
+    index:       Option<u32>
+    level:       Option<String>
+    image_index: u32
+    description: String
+}
+```
+
+---
+
+## 06 · Table Types
+
+**Source:** [`models/table.rs`](../crates/edgeparse-core/src/models/table.rs)
+
+```
+TableBorder {
+    bbox:             BoundingBox
+    index:            Option<u32>
+    level:            Option<String>
+    x_coordinates:    Vec<f64>         // N+1 column boundary X positions
+    x_widths:         Vec<f64>         // border line widths at each X
+    y_coordinates:    Vec<f64>         // M+1 row boundary Y positions
+    y_widths:         Vec<f64>         // border line widths at each Y
+    rows:             Vec<TableBorderRow>
+    num_rows:         usize            // M
+    num_columns:      usize            // N
+    is_bad_table:     bool
+    is_table_transformer: bool
+    previous_table:   Option<Box<TableBorder>>  // cross-page chain
+    next_table:       Option<Box<TableBorder>>  // cross-page chain
+}
+
+TableBorderRow {
+    bbox:           BoundingBox
+    index:          Option<u32>
+    level:          Option<String>
+    row_number:     usize              // 0-based
+    cells:          Vec<TableBorderCell>
+    semantic_type:  Option<SemanticType>  // TableHeaders/TableBody/TableFooter
+}
+
+TableBorderCell {
+    bbox:            BoundingBox
+    index:           Option<u32>
+    level:           Option<String>
+    row_number:      usize             // 0-based
+    col_number:      usize             // 0-based
+    row_span:        usize
+    col_span:        usize
+    text_chunks:     Vec<TextChunk>    // assigned by Stage 4b
+    semantic_type:   Option<SemanticType>  // TableHeader / TableCell
+}
+```
+
+**Grid visualisation:**
+```
+x_coordinates: [50, 200, 350, 500]  (4 values = 3 columns)
+y_coordinates: [700, 680, 660, 640] (4 values = 3 rows)
+
+     50   200   350   500
+700   ┼─────┼─────┼─────┼
+      │ 0,0 │ 0,1 │ 0,2 │
+680   ┼─────┼─────┼─────┼
+      │ 1,0 │ 1,1 │ 1,2 │
+660   ┼─────┼─────┼─────┼
+      │ 2,0 │ 2,1 │ 2,2 │
+640   ┼─────┼─────┼─────┼
+```
+
+---
+
+## 07 · ContentElement Enum (Unified)
+
+**Source:** [`models/content.rs`](../crates/edgeparse-core/src/models/content.rs)
+
+```rust
+pub enum ContentElement {
+    // Raw (early pipeline)
+    TextChunk(TextChunk),
+    Image(ImageChunk),
+    Line(LineChunk),
+    LineArt(LineArtChunk),
+    TableBorder(TableBorder),
+
+    // Grouped (mid pipeline)
+    TextLine(TextLine),
+    TextBlock(TextBlock),
+    List(PDFList),
+
+    // Semantic (late pipeline)
+    Paragraph(SemanticParagraph),
+    Heading(SemanticHeading),
+    NumberHeading(SemanticNumberHeading),
+    Caption(SemanticCaption),
+    HeaderFooter(SemanticHeaderOrFooter),
+    Figure(SemanticFigure),
+    Formula(SemanticFormula),
+    Picture(SemanticPicture),
+    Table(SemanticTable),
+}
+```
+
+The enum implements:
+- `bbox()` → `&BoundingBox` (dispatches to inner type)
+- `index()` → `Option<u32>`
+- `page_number()` → `Option<u32>`
+- `set_index(u32)` → used by Stage 13
+
+Early stages produce `TextChunk`/`Line`/`Image`. Late stages produce `Heading`/`Paragraph`/`Table`. The enum spans the full lifecycle in one type.
+
+---
+
+## 08 · SemanticType Enum
+
+**Source:** [`models/enums.rs`](../crates/edgeparse-core/src/models/enums.rs)
+
+```
+Document, Div, Paragraph, Span, Table, TableHeaders, TableFooter,
+TableBody, TableRow, TableHeader, TableCell, Form, Link, Annot,
+Caption, List, ListLabel, ListBody, ListItem, TableOfContent,
+TableOfContentItem, Figure, NumberHeading, Heading, Title,
+BlockQuote, Note, Header, Footer, Code, Part
+```
+
+`is_ignored_standard_type()` returns `true` for `Div`, `Span`, `Form`, `Link`, `Annot` — these are structural PDF tags useful for parsing but suppressed from output.
+
+---
+
+## 09 · PdfDocument (Root Output Type)
+
+**Source:** [`models/document.rs`](../crates/edgeparse-core/src/models/document.rs)
+
+```
+PdfDocument {
+    file_name:         String
+    number_of_pages:   u32
+    author:            Option<String>
+    title:             Option<String>
+    creation_date:     Option<String>
+    modification_date: Option<String>
+    producer:          Option<String>
+    creator:           Option<String>
+    subject:           Option<String>
+    keywords:          Option<String>
+    kids:              Vec<ContentElement>  // all semantic content, reading order
+}
+```
+
+`metadata_pairs()` returns a `Vec<(&str, &str)>` for rendering — only non-empty fields are included.
+
+---
+
+## 10 · Tagged PDF — McidMap
+
+**Source:** [`tagged/struct_tree.rs`](../crates/edgeparse-core/src/tagged/struct_tree.rs)
+
+For PDFs with accessibility tags (`/StructTreeRoot`), the structure tree is parsed into:
+
+```
+McidMap = HashMap<(page_number: u32, mcid: i64), McidTagInfo>
+
+McidTagInfo {
+    role:          &'static str    // "heading", "paragraph", "table", ...
+    heading_level: Option<u32>    // 1-6 for H/H1-H6 structure nodes
+    struct_type:   String          // raw tag, e.g. "H2", "P", "Table"
+}
+```
+
+`build_mcid_map()` walks the structure tree, resolves the `RoleMap` (custom tag aliases), and populates the map. Stage 12 (`heading_detector`) consults this map for authoritative heading classification when available.
+
+---
+
+## 11 · Page Geometry — PageInfo
+
+**Source:** [`pdf/page_info.rs`](../crates/edgeparse-core/src/pdf/page_info.rs)
+
+```
+PageInfo {
+    index:       usize         // 0-based position in Vec<PageInfo>
+    page_number: u32           // 1-based PDF page number
+    media_box:   BoundingBox   // full physical page (PDF /MediaBox)
+    crop_box:    BoundingBox   // visible area (/CropBox; defaults to MediaBox)
+    rotation:    i64           // 0 | 90 | 180 | 270 degrees
+    width:       f64           // media_box.width()
+    height:      f64           // media_box.height()
+}
+```
+
+Used by:
+- Stage 2 (`content_filter`) — filter elements outside `crop_box`
+- Stage 8 (`header_footer`) — compute header/footer Y thresholds
+- Stage 5b (`column_detector`) — page width for column ratio
+- Stage 18 (`reading_order`) — XY-Cut page region boundary
+
+---
+
+## Cross-Reference
+
+| Topic | Document |
+|-------|---------|
+| How types are produced | [02-pipeline.md](02-pipeline.md) |
+| Where types originate (parsing) | [04-pdf-extraction.md](04-pdf-extraction.md) |
+| How types are serialised | [05-output-formats.md](05-output-formats.md) |

--- a/docs/04-pdf-extraction.md
+++ b/docs/04-pdf-extraction.md
@@ -1,0 +1,380 @@
+# EdgeParse — PDF Extraction Layer
+
+> Explains how raw PDF bytes become `PageChunks` before the 20-stage pipeline begins.
+
+---
+
+## 01 · Extraction Architecture
+
+```
+PDF File (bytes)
+    │
+    ▼ loader::load_pdf()                   [pdf/loader.rs]
+    │
+    ├── lopdf::Document::load()
+    │     └── Parses cross-reference table (xref)
+    │         Parses trailer dictionary
+    │         Handles linearised PDFs
+    │         Handles encrypted PDFs (RC4/AES)
+    │
+    ├── RawPdfDocument {
+    │     document: lopdf::Document   ← in-memory PDF object graph
+    │     num_pages: u32
+    │     metadata: PdfMetadata { author, title, creation_date, modification_date }
+    │   }
+    │
+    ▼ page_info::extract_page_info()       [pdf/page_info.rs]
+    │
+    │   For each page:
+    │   ├── Read /MediaBox → BoundingBox
+    │   ├── Read /CropBox  → BoundingBox (or clone MediaBox)
+    │   └── Read /Rotate   → i64
+    │
+    ▼ chunk_parser::extract_page_chunks()  [pdf/chunk_parser.rs]
+    │   (one call per page, parallelisable at call site)
+    │
+    │   1. resolve_page_fonts()  → FontCache
+    │   2. get_page_content()    → Vec<u8> (merged decompressed streams)
+    │   3. Content::decode()     → Vec<Operation>
+    │   4. ChunkParserState::process_operations() → PageChunks
+    │
+    ▼ PageChunks {
+         text_chunks:      Vec<TextChunk>
+         image_chunks:     Vec<ImageChunk>
+         line_chunks:      Vec<LineChunk>
+         line_art_chunks:  Vec<LineArtChunk>
+       }
+```
+
+---
+
+## 02 · PDF Loading
+
+**Source:** [`pdf/loader.rs`](../crates/edgeparse-core/src/pdf/loader.rs)
+
+```rust
+pub fn load_pdf(path: &Path, password: Option<&str>) -> Result<RawPdfDocument, EdgePdfError>
+```
+
+Uses `lopdf::Document::load()` (via `pdf-cos` fork). Internally:
+
+1. Opens file
+2. Parses xref table (supports PDF 1.0–1.7, PDF 2.0 cross-reference streams)
+3. Decrypts if password provided (see `pdf/encryption.rs`)
+4. Builds in-memory object graph (lazy: streams not decompressed yet)
+
+After loading, `extract_metadata()` reads the `/Info` dictionary:
+```
+/Info dictionary keys read:
+  Author, Title, CreationDate, ModDate
+```
+
+---
+
+## 03 · Content Stream Parsing
+
+**Source:** [`pdf/chunk_parser.rs`](../crates/edgeparse-core/src/pdf/chunk_parser.rs)
+
+One call to `extract_page_chunks()` does a single-pass walk of all content stream operators on a page.
+
+### Content Stream Acquisition
+
+```rust
+// get_page_content() — pdf/text_extractor.rs (reused by chunk_parser)
+match page_dict.get("Contents") {
+    Object::Reference(id) → dereference → Object::Stream → decompressed bytes
+    Object::Array(refs)   → collect + concatenate all stream bytes
+}
+```
+
+Multiple content streams per page are concatenated with a space separator to maintain operator boundary safety.
+
+### Content Stream Operators Handled
+
+```
+TEXT OPERATORS
+  BT / ET          ── begin/end text object
+  Tf name size     ── set font + size
+  Td dx dy         ── move text position (offset)
+  TD dx dy         ── move + set leading
+  Tm a b c d e f  ── set text matrix
+  T*               ── move to next line
+  Tj string        ── show string
+  TJ array         ── show string array (with kerning adjustments)
+  '  string        ── move to next line, show string
+  "  aw ac string  ── set word+char spacing, show string
+
+GRAPHICS STATE
+  q / Q            ── push / pop graphics state stack
+  cm a b c d e f  ── concatenate CTM (current transform matrix)
+  gs name          ── apply extended graphics state from /ExtGState
+  w                ── set line width
+  J / j            ── set line cap / join style
+
+PATH OPERATORS
+  m x y            ── move to
+  l x y            ── line to
+  c ...            ── cubic bezier
+  v / y ...        ── alternate bezier
+  re x y w h      ── rectangle
+  S / s            ── stroke path
+  f / F            ── fill path
+  B / b            ── fill + stroke
+  n                ── end path (no paint)
+  h                ── close subpath
+
+IMAGE OPERATORS
+  Do name          ── invoke XObject (image or form)
+  BI/ID/EI         ── inline image
+
+COLOR OPERATORS
+  g / G            ── gray fill / stroke
+  rg / RG          ── RGB fill / stroke
+  k / K            ── CMYK fill / stroke
+  cs / CS          ── set colorspace
+  sc / SC / scn    ── set color components
+
+MARKED CONTENT
+  BMC / BDC        ── begin marked content
+  EMC              ── end marked content
+```
+
+### ChunkParserState Internal State
+
+```
+ChunkParserState {
+    page_number:    u32
+    font_cache:     FontCache           // resolved fonts for this page
+    graphics_stack: GraphicsStateStack  // q/Q push/pop stack
+    current_font:   Option<(name, PdfFont)>
+    current_color:  [f64; 4]           // fill color (RGB/CMYK/Gray)
+    text_matrix:    Matrix             // Tm — text position matrix
+    line_matrix:    Matrix             // Tlm — line position matrix
+    mcid_stack:     Vec<Option<i64>>   // BDC/EMC marked content stack
+    chunks:         Vec<TextChunk>
+    images:         Vec<ImageChunk>
+    lines:          Vec<(start, end, width)>  // pending path segments
+    paths:          Vec<Vec<Vertex>>   // complex paths
+}
+```
+
+---
+
+## 04 · Graphics State Machine
+
+**Source:** [`pdf/graphics_state.rs`](../crates/edgeparse-core/src/pdf/graphics_state.rs)
+
+The graphics state machine tracks the CTM (Current Transformation Matrix) and color state across `q`/`Q` push/pop boundaries.
+
+```
+GraphicsStateStack {
+    stack: Vec<GraphicsState>
+}
+
+GraphicsState {
+    ctm:          Matrix   // current transformation matrix [a b c d e f]
+    fill_color:   [f64; 4]
+    stroke_color: [f64; 4]
+    line_width:   f64
+    text_state:   TextState {
+        font_size, char_spacing, word_spacing, text_rise, text_leading
+    }
+}
+
+Matrix [a b c d e f]:
+  a  b  0
+  c  d  0
+  e  f  1
+
+Transform: (x', y') = (a*x + c*y + e, b*x + d*y + f)
+```
+
+**CTM usage for text positioning:**
+```
+Tm (text matrix) × CTM → absolute page coordinates of glyph
+```
+
+**CTM usage for image positioning:**
+```
+/Do XObject: current CTM defines image bounding box as CTM × unit square
+  → bbox = { left_x: e, bottom_y: f, right_x: e+a, top_y: f+d }
+```
+
+---
+
+## 05 · Font Resolution
+
+**Source:** [`pdf/font.rs`](../crates/edgeparse-core/src/pdf/font.rs)
+
+```
+resolve_page_fonts(doc, page_id) → FontCache
+
+FontCache = HashMap<fontname: Vec<u8>, PdfFont>
+
+PdfFont {
+    base_font_name:  String
+    font_size:       f64          // from Tf operator
+    font_weight:     f64          // from font descriptor
+    italic_angle:    f64          // from font descriptor
+    encoding:        Encoding     // StandardEncoding | WinAnsiEncoding | custom
+    cmap:            Option<ToUnicode>  // CMap for non-Latin scripts
+    widths:          Vec<f64>     // glyph advance widths
+    first_char:      u32          // first encoded character code
+}
+```
+
+### Glyph → Unicode Mapping
+
+```
+Priority order:
+  1. ToUnicode CMap (highest fidelity for complex scripts)
+  2. Encoding array (StandardEncoding, WinAnsiEncoding, MacRomanEncoding)
+  3. GlyphName → Unicode via AGL (Adobe Glyph List)
+  4. Direct byte value (Latin-1 fallback)
+  5. U+FFFD (replaced by Stage 2b)
+```
+
+### CMap Parsing
+
+**Source:** [`pdf-cos/src/encodings/cmap.rs`](../crates/pdf-cos/src/encodings/cmap.rs)
+
+Parses `beginbfchar` / `endbfchar` / `beginbfrange` / `endbfrange` sections to build code → Unicode mappings for:
+- Type0 (CIDFont) composite fonts
+- Type1/TrueType fonts with custom encoding
+
+---
+
+## 06 · Glyph Positioning
+
+When the `Tj` or `TJ` operator fires:
+
+```
+For each glyph code c:
+  1. Look up (c → Unicode) via font encoding/CMap
+  2. Advance width = PdfFont.widths[c - first_char] (or fallback)
+  3. Apply text matrix: glyph_x = Tm.e, glyph_y = Tm.f
+  4. Apply CTM: page_x = CTM.transform(glyph_x, glyph_y)
+  5. Accumulate glyph for current TextChunk
+  6. Advance Tm by width * font_size / 1000
+
+TJ array kerning:
+  Negative number → advance left (tighter spacing)
+  Positive number → advance right (looser spacing)
+  Threshold: |kern| > font_size * 0.3 → split into new TextChunk
+```
+
+`symbol_ends` in `TextChunk` records the right X of each glyph.
+
+---
+
+## 07 · Image Extraction
+
+**Source:** [`pdf/image_extractor.rs`](../crates/edgeparse-core/src/pdf/image_extractor.rs), handled in `chunk_parser.rs`
+
+### XObject Images (`Do` operator)
+
+```
+Do /ImageName
+  → look up XObject in /Resources/XObject dictionary
+  → if /Subtype == /Image:
+      bbox from CTM × unit_square
+      emit ImageChunk{bbox}
+  → if /Subtype == /Form:
+      save state, apply /Matrix, recurse process_operations()
+```
+
+Recursion depth limited by `MAX_FORM_RECURSION_DEPTH = 10` to prevent infinite loops from self-referential Forms.
+
+### Inline Images (`BI`/`ID`/`EI`)
+
+Inline images appear directly in the content stream between `BI` (begin image) and `EI` (end image) markers. Parsed from the raw content bytes; bounding box computed from the current CTM.
+
+---
+
+## 08 · Line / Path Extraction
+
+**Source:** [`pdf/line_extractor.rs`](../crates/edgeparse-core/src/pdf/line_extractor.rs), `chunk_parser.rs`
+
+```
+Path lifecycle:
+  m x y    → start new subpath vertex
+  l x y    → add line segment
+  re x y w h → add rectangle (4 vertices)
+  c,v,y    → Bezier (sampled to endpoints for bbox)
+  h         → close subpath
+  S/f/B/n   → paint/end path
+
+Classification after path is complete:
+  Segment count == 1 AND aspect > LINE_ASPECT_RATIO (3.0) AND thickness < 10pt
+    → LineChunk { is_horizontal_line: true/false }
+
+  Segment count == 4 (rectangle) AND small size
+    → LineChunk { is_square: true }
+
+  Otherwise (complex path, compound figure)
+    → LineArtChunk { line_chunks: [...] }
+```
+
+Constants:
+- `LINE_ASPECT_RATIO = 3.0` (width/height threshold for line classification)
+- `MAX_LINE_THICKNESS = 10.0` pt
+- `MIN_LINE_WIDTH = 0.1` pt (below this: invisible, skip)
+
+---
+
+## 09 · Raster Table OCR Recovery
+
+**Source:** [`pdf/raster_table_ocr.rs`](../crates/edgeparse-core/src/pdf/raster_table_ocr.rs)
+
+When a PDF page contains a raster image that looks like a table (dense horizontal/vertical lines within the image pixels), this module attempts to recover the table structure by:
+
+1. Rendering the page region to a pixel buffer
+2. Detecting horizontal/vertical dark line segments in the pixel data
+3. Converting pixel coordinates to PDF coordinate space using the CropBox
+4. Emitting `TableBorder` elements
+
+This is a fallback path for scanned documents where table borders are embedded in raster images rather than as PDF path operators.
+
+---
+
+## 10 · Marked Content / Tagged PDFs
+
+**Source:** [`tagged/struct_tree.rs`](../crates/edgeparse-core/src/tagged/struct_tree.rs)
+
+Tagged PDFs embed accessibility structure via:
+- Content stream: `BDC /tag <</MCID N>>` … `EMC` operators
+- Catalogue: `/StructTreeRoot` → tree of structure elements
+
+The chunk parser records `mcid: Option<i64>` on each `TextChunk` from the innermost BDC context.
+
+`build_mcid_map(doc)` then creates:
+```
+McidMap: (page_number, mcid) → McidTagInfo { role, heading_level, struct_type }
+```
+
+Stage 12 (`heading_detector`) uses this map to promote chunks tagged as `H`, `H1`–`H6` directly to headings.
+
+---
+
+## 11 · Encryption
+
+**Source:** [`pdf/encryption.rs`](../crates/edgeparse-core/src/pdf/encryption.rs)
+**pdf-cos:** [`crates/pdf-cos/src/encryption/`](../crates/pdf-cos/src/encryption/)
+
+Supports:
+- RC4 40-bit (PDF 1.1–1.3)
+- RC4 128-bit (PDF 1.4)
+- AES 128-bit (PDF 1.5–1.6)
+- AES 256-bit (PDF 1.7, ISO 32000-2)
+
+Password is passed through `config.password` → `loader::load_pdf(path, password)`.
+
+---
+
+## Cross-Reference
+
+| Topic | Document |
+|-------|---------|
+| Data types produced here | [03-data-model.md](03-data-model.md) |
+| Pipeline that processes these chunks | [02-pipeline.md](02-pipeline.md) |
+| Architecture overview | [01-architecture.md](01-architecture.md) |

--- a/docs/05-output-formats.md
+++ b/docs/05-output-formats.md
@@ -1,0 +1,328 @@
+# EdgeParse — Output Formats
+
+> All renderers take a fully-classified `PdfDocument` (post-pipeline) and return `Result<String, EdgePdfError>`.
+
+---
+
+## 01 · Renderer Map
+
+```
+PdfDocument
+    │
+    ├── output::legacy_json::to_legacy_json_string()  → .json   [legacy_json.rs]
+    ├── output::json::to_json()                        → .json   [json.rs]
+    ├── output::markdown::to_markdown()               → .md    [markdown.rs]
+    ├── output::html::to_html()                       → .html  [html.rs]
+    ├── output::text::to_text()                       → .txt   [text.rs]
+    └── output::csv::to_csv()                         → .csv   [csv.rs]
+```
+
+All live in [`crates/edgeparse-core/src/output/`](../crates/edgeparse-core/src/output/).
+
+The CLI and SDKs select a renderer via `OutputFormat` enum after converting the document at [`edgeparse-cli/src/main.rs#L143`](../crates/edgeparse-cli/src/main.rs#L143).
+
+---
+
+## 02 · Legacy JSON (`legacy_json.rs`)
+
+**Source:** [`output/legacy_json.rs`](../crates/edgeparse-core/src/output/legacy_json.rs)
+**Function:** `to_legacy_json_string(doc: &PdfDocument, stem: &str) → Result<String>`
+
+This is the **default output format** (used when `--format json` or no format specified).
+
+### Key Schema Characteristics
+
+| Feature | Detail |
+|---------|--------|
+| Key style | Space-separated: `"file name"`, `"page number"`, `"bounding box"` |
+| BoundingBox | `[left_x, bottom_y, right_x, top_y]` float array |
+| IDs | Globally sequential integers starting from 1 |
+| Color | `"[r, g, b]"` or `"[k]"` string (preserves original color space) |
+| Font names | Subset prefix stripped: `"ABCDEF+Helvetica"` → `"Helvetica"` |
+
+### Document-Level Fields
+
+```json
+{
+  "file name": "report.pdf",
+  "number of pages": 10,
+  "title": "Annual Report",
+  "author": "Alice Smith",
+  "creation date": "D:20240101",
+  "modification date": "D:20240201",
+  "elements": [ ... ]
+}
+```
+
+### Element Schema
+
+Every element has:
+```json
+{
+  "id": 42,
+  "type": "paragraph",
+  "bounding box": [72.0, 680.0, 540.0, 700.0],
+  "page number": 1
+}
+```
+
+Type-specific fields:
+
+**Heading / paragraph:**
+```json
+{
+  "type": "heading",
+  "level": "h1",
+  "value": "Introduction",
+  "font name": "Helvetica-Bold",
+  "font size": "14.0",
+  "font weight": "700.0",
+  "text color": "[0.0, 0.0, 0.0]"
+}
+```
+
+**Table:**
+```json
+{
+  "type": "table",
+  "rows": [
+    {
+      "type": "table row",
+      "cells": [
+        { "type": "table header cell", "value": "Name" },
+        { "type": "table data cell",   "value": "Alice" }
+      ]
+    }
+  ]
+}
+```
+
+**List:**
+```json
+{
+  "type": "list",
+  "list items": [
+    { "type": "list item", "label value": "•", "body value": "First item" }
+  ]
+}
+```
+
+### ID Counter
+
+The legacy JSON serialiser uses a thread-local counter (`NEXT_ID`) reset at the start of each document:
+```rust
+thread_local! {
+    static NEXT_ID: Cell<u64> = Cell::new(1);
+}
+```
+**Source:** [`legacy_json.rs#L31`](../crates/edgeparse-core/src/output/legacy_json.rs#L31)
+
+---
+
+## 03 · Markdown (`markdown.rs`)
+
+**Source:** [`output/markdown.rs`](../crates/edgeparse-core/src/output/markdown.rs)
+**Function:** `to_markdown(doc: &PdfDocument) → Result<String>`
+
+### Element Mapping
+
+| ContentElement | Markdown output |
+|---------------|-----------------|
+| `Heading{level=1}` | `# Heading text` |
+| `Heading{level=2}` | `## Heading text` |
+| `NumberHeading{level=2}` | `## 1.2 Heading text` |
+| `Paragraph` | `Paragraph text\n\n` |
+| `List` | `- item 1\n- item 2\n` |
+| `Table` (with borders) | GFM table: `\| col1 \| col2 \|` |
+| `Figure` | `![Image]\n` |
+| `Caption` | Appended after figure/table |
+| `HeaderFooter` | Skipped (unless `include_header_footer=true`) |
+| `TextBlock` | Treated as paragraph (fallback) |
+
+### Special-Case Document Detection
+
+The markdown renderer has two special-case document detectors that produce cleaner output for specific document types:
+
+```rust
+if looks_like_contents_document(doc) {
+    return Ok(render_contents_document(doc));
+}
+if looks_like_compact_toc_document(doc) {
+    return Ok(render_compact_toc_document(doc));
+}
+```
+
+These detect documents that are primarily a Table of Contents and render them without heading noise.
+
+### Heading Demotion
+
+When a heading is very long or followed immediately by a paragraph that semantically "continues" it, the renderer promotes the heading to a plain paragraph to avoid spurious `#` markers:
+
+```rust
+if should_demote_heading_to_paragraph(trimmed, &next_text) {
+    // merge heading + next paragraph as plain text
+}
+```
+
+### Markdown-Start Escaping
+
+Lines beginning with `-`, `*`, `#`, `>`, etc. that are not intended as Markdown syntax are escaped:
+```rust
+escape_md_line_start(text) → adds U+200B zero-width space prefix
+```
+
+---
+
+## 04 · HTML5 (`html.rs`)
+
+**Source:** [`output/html.rs`](../crates/edgeparse-core/src/output/html.rs)
+**Function:** `to_html(doc: &PdfDocument) → Result<String>`
+
+### Document Template
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{doc.title or doc.file_name}</title>
+</head>
+<body>
+  {elements}
+</body>
+</html>
+```
+
+### Element Mapping
+
+| ContentElement | HTML tag |
+|---------------|----------|
+| `Heading{level=N}` | `<hN>text</hN>` |
+| `Paragraph` | `<p>text</p>` |
+| `List` | `<ul><li>…</li></ul>` |
+| `Image` | `<img src="image" alt="Image">` |
+| `TextBlock` | `<p>text</p>` (fallback) |
+| `TextLine` | `<span>text</span>` (fallback) |
+| `TextChunk` | bare text node |
+| `HeaderFooter` | skipped by default |
+
+HTML special characters are escaped via `html_escape()`:
+```
+& → &amp;
+< → &lt;
+> → &gt;
+```
+
+### Table HTML
+
+Tables use full semantic markup:
+```html
+<table>
+  <thead><tr><th>Col A</th><th>Col B</th></tr></thead>
+  <tbody>
+    <tr><td>val1</td><td>val2</td></tr>
+  </tbody>
+</table>
+```
+
+---
+
+## 05 · Plain Text (`text.rs`)
+
+**Source:** [`output/text.rs`](../crates/edgeparse-core/src/output/text.rs)
+**Function:** `to_text(doc: &PdfDocument) → Result<String>`
+
+Simplest renderer. Text separated by `\n\n` between elements.
+
+### Element Mapping
+
+| ContentElement | Text output |
+|---------------|------------|
+| `Heading` | `text\n\n` |
+| `Paragraph` | `text\n\n` |
+| `List` / item | `  label body\n` |
+| `Image` | `[Image]\n\n` |
+| `TextBlock` | `text\n\n` |
+| `HeaderFooter` | skipped |
+
+### Page Separator
+
+If `config.text_page_separator` is set, it is inserted between pages when flattening to text.
+
+---
+
+## 06 · CSV (`csv.rs`)
+
+**Source:** [`output/csv.rs`](../crates/edgeparse-core/src/output/csv.rs)
+
+Extracts all tables from the document and renders them as CSV. Each table becomes a separate section. Non-table elements are skipped.
+
+---
+
+## 07 · TOC Builder (`toc_builder.rs`)
+
+**Source:** [`output/toc_builder.rs`](../crates/edgeparse-core/src/output/toc_builder.rs)
+
+Helper used by markdown and HTML renderers to extract a table of contents from `Heading` elements:
+
+```
+toc_builder::build_toc(doc) → Vec<TocEntry>
+
+TocEntry {
+    level:   u32
+    text:    String
+    anchor:  String   // slug of heading text
+}
+```
+
+---
+
+## 08 · Output Format Selection Flow
+
+```
+CLI: --format json,markdown
+           │
+           ▼
+    build_config() → ProcessingConfig.formats: Vec<OutputFormat>
+           │
+           ▼
+    edgeparse_core::convert() → PdfDocument
+           │
+           ▼
+    write_outputs():
+      for fmt in config.formats:
+        match fmt:
+          OutputFormat::Json     → legacy_json::to_legacy_json_string()  → .json
+          OutputFormat::Text     → text::to_text()                        → .txt
+          OutputFormat::Html     → html::to_html()                        → .html
+          OutputFormat::Markdown → markdown::to_markdown()                → .md
+          OutputFormat::Pdf      → log::warn! (not yet implemented)
+```
+
+**Source:** [`edgeparse-cli/src/main.rs`](../crates/edgeparse-cli/src/main.rs#L143)
+
+---
+
+## 09 · Format Comparison Matrix
+
+| Feature | JSON | Markdown | HTML | Text |
+|---------|------|----------|------|------|
+| Structured data | ✅ full schema | ✗ | ✗ | ✗ |
+| Human readable | ⚠️ verbose | ✅ | ✅ | ✅ |
+| Table support | ✅ full cells | ✅ GFM | ✅ semantic | ⚠️ flat |
+| Heading levels | ✅ field | ✅ `#` prefix | ✅ `<h1>` | ✗ (flat) |
+| Bounding boxes | ✅ | ✗ | ✗ | ✗ |
+| Font info | ✅ | ✗ | ✗ | ✗ |
+| Page numbers | ✅ | ✗ (optional sep) | ✗ | ✗ |
+| Image data | ✅ (base64 if embedded) | ✅ `![]()` | ✅ `<img>` | `[Image]` |
+| Cross-page tables | ✅ linked | ✅ rendered | ✅ rendered | ✅ flat |
+
+---
+
+## Cross-Reference
+
+| Topic | Document |
+|-------|---------|
+| How doc.kids is populated | [02-pipeline.md](02-pipeline.md) |
+| ContentElement types | [03-data-model.md](03-data-model.md) |
+| CLI format flag | [06-sdk-integration.md](06-sdk-integration.md) |


### PR DESCRIPTION
This PR removes the MinerU, Marker, and EdgeQuake engines from the benchmark suite, updates all relevant scripts, and cleans up their results. Ready for review and merge to main.