### PR TITLE
docs: add Homebrew installation instructions

### DIFF
--- a/site/src/content/docs/getting-started/quick-start-cli.mdx
+++ b/site/src/content/docs/getting-started/quick-start-cli.mdx
@@ -1,15 +1,39 @@
 ---
 title: "Quick Start: CLI"
-description: "Extract PDFs from the command line with edgeparse-cli."
+description: "Extract PDFs from the command line with edgeparse-cli. Install via Homebrew, cargo, or pre-built binary."
 ---
 
 ## Installation
+
+### Homebrew (macOS / Linux) — Recommended
+
+```bash
+brew tap raphaelmansuy/tap
+brew install edgeparse
+```
+
+Verify:
+
+```bash
+edgeparse --version
+```
+
+### cargo (any platform)
 
 ```bash
 cargo install edgeparse-cli
 ```
 
-Or download a pre-built binary from [GitHub Releases](https://github.com/raphaelmansuy/edgeparse/releases).
+### Pre-built binary
+
+Download a platform binary from [GitHub Releases](https://github.com/raphaelmansuy/edgeparse/releases), make it executable, and add it to your `PATH`:
+
+```bash
+# macOS arm64 example
+curl -L https://github.com/raphaelmansuy/edgeparse/releases/latest/download/edgeparse-aarch64-apple-darwin.tar.gz | tar xz
+chmod +x edgeparse
+sudo mv edgeparse /usr/local/bin/
+```
 
 ## Basic Usage
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -41,6 +41,21 @@ npx skills add raphaelmansuy/edgeparse --skill edgeparse
 
 # Step 2: Install the Python runtime
 pip install edgeparse` },
+    { label: 'Brew', lang: 'bash', code: `# macOS / Linux — one-time setup
+brew tap raphaelmansuy/tap
+brew install edgeparse
+
+# Verify installation
+edgeparse --version
+
+# Parse a PDF to Markdown
+edgeparse report.pdf --format markdown
+
+# Parse to JSON with bounding boxes
+edgeparse invoice.pdf --format json
+
+# Batch convert a directory
+edgeparse docs/*.pdf --format markdown --output-dir results/` },
     { label: 'Python', lang: 'python', code: `import edgeparse, json
 
 # Convert PDF to Markdown
@@ -72,7 +87,10 @@ const pages = convert("report.pdf", { format: "markdown", pages: "1-5" });
 
 // Save to output directory
 const path = convertFile("report.pdf", { outputDir: "out/", format: "markdown" });` },
-    { label: 'CLI', lang: 'bash', code: `# Install
+    { label: 'CLI', lang: 'bash', code: `# Install via Homebrew (macOS / Linux)
+brew tap raphaelmansuy/tap && brew install edgeparse
+
+# Or via pip
 pip install edgeparse
 
 # Extract PDF to Markdown


### PR DESCRIPTION
## Summary

Adds Homebrew as the **recommended** installation method for EdgeParse CLI.

### Changes

- **`quick-start-cli.mdx`** — New Installation section with three methods in priority order:
  1. Homebrew (macOS / Linux) — Recommended
  2. cargo (any platform)
  3. Pre-built binary
- **`index.mdx`** — New **Brew** tab in the landing-page QuickStart component; CLI tab updated to show brew as primary install option

### Brew Commands

```bash
brew tap raphaelmansuy/tap
brew install edgeparse
```

Formula verified live at `raphaelmansuy/homebrew-tap`.

### Build

- 31 pages build cleanly ✅
- `sitemap-index.xml` generated ✅