### PR TITLE
feat(site): add Demo link to header navigation

### DIFF
--- a/site/src/components/SocialIcons.astro
+++ b/site/src/components/SocialIcons.astro
@@ -10,6 +10,7 @@
     <a href="/getting-started/quick-start-python/" class="nav-link">Docs</a>
     <a href="/guides/rag-integration/" class="nav-link">Guides</a>
     <a href="/benchmark/results/" class="nav-link">Benchmark</a>
+    <a href="/demo/" class="nav-link nav-link--demo">Demo</a>
   </nav>
   <div class="social-actions">
     <a
@@ -56,6 +57,15 @@
   .nav-link:hover {
     color: var(--sl-color-white);
     background-color: var(--sl-color-gray-6, rgba(255,255,255,0.08));
+  }
+
+  .nav-link--demo {
+    color: var(--sl-color-accent, #4F46E5);
+  }
+
+  .nav-link--demo:hover {
+    color: #fff;
+    background-color: var(--sl-color-accent, #4F46E5);
   }
 
   .social-actions {


### PR DESCRIPTION
Adds a 'Demo' link to the site header nav bar (SocialIcons component) pointing to /demo/. Styled with accent color to stand out.