### PR TITLE
feat(site): add demo and Elitizon links across the site

### DIFF
--- a/site/src/components/enterprise/EnterpriseContent.astro
+++ b/site/src/components/enterprise/EnterpriseContent.astro
@@ -172,7 +172,11 @@ const base = import.meta.env.BASE_URL;
       <strong>Docker deployment</strong>
       <span>Run EdgeParse in containers with pre-built images.</span>
     </a>
-    <a href="https://elitizon.com/" target="_blank" rel="noopener noreferrer" class="ent-link-card">
+    <a href="/demo/" class="ent-link-card">
+      <strong>Live demo</strong>
+      <span>Try EdgeParse in your browser — no install, no server, pure WebAssembly.</span>
+    </a>
+    <a href="https://www.elitizon.com/" target="_blank" rel="noopener noreferrer" class="ent-link-card">
       <strong>Implementation support</strong>
       <span>Talk to the team about architecture reviews, rollout planning, or custom integration work.</span>
     </a>

--- a/site/src/components/landing/CtaSection.astro
+++ b/site/src/components/landing/CtaSection.astro
@@ -28,6 +28,12 @@ const base = import.meta.env.BASE_URL;
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
       </svg>
     </a>
+    <a href="/demo/" class="btn-secondary">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" width="16" height="16" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 0 1 0 1.972l-11.54 6.347a1.125 1.125 0 0 1-1.667-.986V5.653Z" />
+      </svg>
+      Try Live Demo
+    </a>
     <a href={secondaryHref} target="_blank" rel="noopener noreferrer" class="btn-secondary">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="16" height="16" aria-hidden="true">
         <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
@@ -35,6 +41,10 @@ const base = import.meta.env.BASE_URL;
       {secondaryText}
     </a>
   </div>
+
+  <p class="cta-enterprise">
+    Enterprise deployment? <a href="https://www.elitizon.com/" target="_blank" rel="noopener noreferrer">Talk to Elitizon</a> about architecture reviews and production rollouts.
+  </p>
 </section>
 
 <style>
@@ -123,5 +133,21 @@ const base = import.meta.env.BASE_URL;
     .cta-section { padding: 3.5rem 1rem; }
     .cta-actions { flex-direction: column; align-items: center; }
     .btn-primary, .btn-secondary { width: 100%; max-width: 280px; justify-content: center; }
+  }
+
+  .cta-enterprise {
+    margin-top: 2rem;
+    font-size: 0.9rem;
+    color: var(--ep-text-secondary, #4B5563);
+  }
+
+  .cta-enterprise a {
+    color: var(--sl-color-accent, #4F46E5);
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .cta-enterprise a:hover {
+    text-decoration: underline;
   }
 </style>

--- a/site/src/content/docs/benchmark/results.mdx
+++ b/site/src/content/docs/benchmark/results.mdx
@@ -38,3 +38,8 @@ description: "EdgeParse vs 6 PDF parsers on 200 documents. NID, TEDS, MHS scores
 - **Corpus:** 200 diverse PDF documents
 - **Mode:** Single-threaded
 - **Categories:** Academic papers, financial reports, invoices, government forms, books, manuals
+
+## See It in Action
+
+- [Try Live Demo](/demo/) — parse any PDF in your browser with WebAssembly, no install needed
+- [Enterprise](/enterprise/) — production-grade deployment with priority support by [Elitizon](https://www.elitizon.com/)

--- a/site/src/content/docs/getting-started/quick-start-cli.mdx
+++ b/site/src/content/docs/getting-started/quick-start-cli.mdx
@@ -76,3 +76,5 @@ edgeparse document.pdf -f json --hybrid docling-fast
 
 - [Output Format Details](/output/json-schema/)
 - [Rust Library Usage](/getting-started/quick-start-rust/)
+- [Try Live Demo](/demo/) — parse PDFs in your browser with WebAssembly
+- [Enterprise](/enterprise/) — self-hosted deployment, priority support by [Elitizon](https://www.elitizon.com/)

--- a/site/src/content/docs/getting-started/quick-start-nodejs.mdx
+++ b/site/src/content/docs/getting-started/quick-start-nodejs.mdx
@@ -52,3 +52,5 @@ const result = convert("document.pdf", {
 
 - [JSON Schema Reference](/output/json-schema/)
 - [Benchmark Results](/benchmark/results/)
+- [Try Live Demo](/demo/) — parse PDFs in your browser with WebAssembly
+- [Enterprise](/enterprise/) — self-hosted deployment, priority support by [Elitizon](https://www.elitizon.com/)

--- a/site/src/content/docs/getting-started/quick-start-python.mdx
+++ b/site/src/content/docs/getting-started/quick-start-python.mdx
@@ -49,4 +49,6 @@ print(f"Saved to: {out_path}")
 ## Next Steps
 
 - [JSON Schema Reference](/output/json-schema/) — understand every field
-- [Benchmark Results](/benchmark/results/) — accuracy &amp; speed data
+- [Benchmark Results](/benchmark/results/) — accuracy & speed data
+- [Try Live Demo](/demo/) — parse PDFs in your browser with WebAssembly
+- [Enterprise](/enterprise/) — self-hosted deployment, priority support by [Elitizon](https://www.elitizon.com/)

--- a/site/src/content/docs/getting-started/quick-start-rust.mdx
+++ b/site/src/content/docs/getting-started/quick-start-rust.mdx
@@ -60,3 +60,5 @@ fn main() -> anyhow::Result<()> {
 
 - [Architecture](/contributing/architecture/)
 - [JSON Schema Reference](/output/json-schema/)
+- [Try Live Demo](/demo/) — parse PDFs in your browser with WebAssembly
+- [Enterprise](/enterprise/) — self-hosted deployment, priority support by [Elitizon](https://www.elitizon.com/)


### PR DESCRIPTION
Add strategic demo and Elitizon links to key pages:

- **Landing CTA**: 'Try Live Demo' button + 'Enterprise? Talk to Elitizon' callout
- **Enterprise page**: demo link card in resources section
- **Quick-start pages** (Python, Node.js, CLI, Rust): demo + enterprise links in Next Steps
- **Benchmark results**: 'See It in Action' section with demo + enterprise links

7 files changed, 45 insertions(+), 2 deletions(-)