### PR TITLE
feat(site): route enterprise links to /contact/ and improve SEO

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -186,7 +186,7 @@ export default defineConfig({
 					tag: 'meta',
 					attrs: {
 						name: 'keywords',
-						content: 'PDF parser, PDF extraction, Rust PDF, structured data, RAG pipeline, table extraction, reading order, Python PDF, Node.js PDF, edgeparse, open source',
+					content: 'PDF parser, PDF extraction, Rust PDF, structured data, RAG pipeline, table extraction, reading order, Python PDF, Node.js PDF, edgeparse, open source, AI agent, PDF to JSON, PDF to markdown, WebAssembly PDF, agent skill, LLM documents',
 					},
 				},
 				{
@@ -194,6 +194,14 @@ export default defineConfig({
 					attrs: {
 						name: 'robots',
 						content: 'index, follow',
+					},
+				},
+				// og:url — canonical URL for social sharing
+				{
+					tag: 'meta',
+					attrs: {
+						property: 'og:url',
+						content: siteUrl,
 					},
 				},
 				// NOTE: canonical is handled per-page by Starlight; do not set a global one.
@@ -311,7 +319,24 @@ export default defineConfig({
 						itemListElement: [
 							{ '@type': 'ListItem', position: 1, name: 'EdgeParse', item: fullUrl },
 							{ '@type': 'ListItem', position: 2, name: 'Documentation', item: `${fullUrl}/getting-started/quick-start-python/` },
+							{ '@type': 'ListItem', position: 3, name: 'Contact', item: `${fullUrl}/contact/` },
 						],
+					}),
+				},
+				// JSON-LD: ContactPage
+				{
+					tag: 'script',
+					attrs: { type: 'application/ld+json' },
+					content: JSON.stringify({
+						'@context': 'https://schema.org',
+						'@type': 'ContactPage',
+						name: 'Contact EdgeParse',
+						url: `${fullUrl}/contact/`,
+						description: 'Contact the EdgeParse team via email, GitHub Discussions, or Elitizon for enterprise engagements.',
+						contactType: 'customer support',
+						email: 'contact@elitizon.com',
+						areaServed: 'Worldwide',
+						availableLanguage: 'English',
 					}),
 				},
 			],
@@ -386,6 +411,13 @@ export default defineConfig({
 					label: 'Releases',
 					items: [
 						{ label: 'Changelog', slug: 'changelog' },
+					],
+				},
+				{
+					label: 'More',
+					items: [
+						{ label: 'Enterprise', slug: 'enterprise' },
+						{ label: 'Contact', slug: 'contact' },
 					],
 				},
 			],

--- a/site/src/components/enterprise/EnterpriseContent.astro
+++ b/site/src/components/enterprise/EnterpriseContent.astro
@@ -128,7 +128,7 @@ const base = import.meta.env.BASE_URL;
 
   </div>
 
-  <a href="https://elitizon.com/" target="_blank" rel="noopener noreferrer" class="ent-cta-button">
+  <a href="/contact/" class="ent-cta-button">
     Talk to the Team
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" width="16" height="16" aria-hidden="true">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"/>
@@ -176,8 +176,8 @@ const base = import.meta.env.BASE_URL;
       <strong>Live demo</strong>
       <span>Try EdgeParse in your browser — no install, no server, pure WebAssembly.</span>
     </a>
-    <a href="https://www.elitizon.com/" target="_blank" rel="noopener noreferrer" class="ent-link-card">
-      <strong>Implementation support</strong>
+    <a href="/contact/" class="ent-link-card">
+      <strong>Contact &amp; support</strong>
       <span>Talk to the team about architecture reviews, rollout planning, or custom integration work.</span>
     </a>
   </div>


### PR DESCRIPTION
Route enterprise Elitizon links to /contact/, expand keywords, add og:url, ContactPage JSON-LD, and More sidebar group.