### PR TITLE
fix: write GitHub Packages auth to NPM_CONFIG_USERCONFIG not ~/.npmrc

### DIFF
--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -178,8 +178,11 @@ jobs:
           fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
           "
           # Write a scoped .npmrc so npm uses the right registry for this scope.
-          echo "@raphaelmansuy:registry=https://npm.pkg.github.com" >> ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
+          # actions/setup-node sets NPM_CONFIG_USERCONFIG to a temp file; append there,
+          # not to ~/.npmrc, so npm actually picks up the GitHub Packages token.
+          NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          echo "@raphaelmansuy:registry=https://npm.pkg.github.com" >> "$NPMRC"
+          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> "$NPMRC"
           cd crates/edgeparse-wasm/pkg
           npm publish --registry https://npm.pkg.github.com \
             || { CODE=$?; echo "GitHub Packages publish exited $CODE — may already exist for this version." ; }


### PR DESCRIPTION
## Root cause

`actions/setup-node` sets `NPM_CONFIG_USERCONFIG` to a temp file (e.g. `/home/runner/work/_temp/.npmrc`). The GitHub Packages publish step was appending the scoped registry and auth token to `~/.npmrc`, which npm never reads — causing `ENEEDAUTH` on every run.

## Fix

Use `${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}` as the target so npm actually picks up the token.

## Verified diagnosis from CI run 24354302693

```
npm error code ENEEDAUTH
```

The npm publish step correctly skipped (already published), but GitHub Packages failed every attempt due to missing auth.