### PR TITLE
chore: set homepage to https://www.edgeparse.com, bump to v0.2.5

### DIFF
--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -79,7 +79,7 @@ jobs:
           const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
           pkg.version     = version;
           pkg.description = 'EdgeParse PDF parser — WebAssembly build for browsers';
-          pkg.homepage    = 'https://edgeparse.io/docs/api/wasm/';
+          pkg.homepage    = 'https://www.edgeparse.com';
           pkg.keywords    = ['pdf', 'parser', 'wasm', 'webassembly', 'browser', 'extraction', 'markdown'];
           pkg.repository  = {
             type: 'git',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.2.5] — 2026-04-14
+
+### Fixed
+- **Homepage URL updated to `https://www.edgeparse.com`** across all published packages (`edgeparse-wasm`, Node.js SDK platform packages, Python SDK) and crate metadata — previously some packages showed `edgeparse.elitizon.com` or stale GitHub URLs
+- **`release-wasm.yml` metadata** — `pkg.homepage` corrected to `https://www.edgeparse.com` so all future WASM npm publishes carry the right URL
+
+### Changed
+- Workspace `Cargo.toml` now declares `homepage = "https://www.edgeparse.com"` inherited by all crates
+- `sdks/node/package.json` and all five platform `package.json` files updated to hompage `https://www.edgeparse.com`
+- `sdks/python/pyproject.toml` `Homepage` updated to `https://www.edgeparse.com`
+
+---
+
 ## [0.2.4] — 2026-04-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,11 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"
+homepage = "https://www.edgeparse.com"
 repository = "https://github.com/raphaelmansuy/edgeparse"
 description = "EdgeParse — High-performance PDF-to-structured-data extraction engine"
 

--- a/crates/edgeparse-wasm/pkg/package.json
+++ b/crates/edgeparse-wasm/pkg/package.json
@@ -1,46 +1,41 @@
 {
   "name": "edgeparse-wasm",
   "type": "module",
-  "description": "EdgeParse PDF parser — WebAssembly build for browsers",
+  "description": "EdgeParse WASM — high-speed PDF-to-Markdown in the browser",
   "version": "0.2.4",
-  "license": "Apache-2.0",
-  "homepage": "https://edgeparse.io/docs/api/wasm/",
+  "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/raphaelmansuy/edgeparse.git",
-    "directory": "crates/edgeparse-wasm"
+    "url": "https://github.com/raphaelmansuy/edgeparse"
   },
-  "keywords": [
-    "pdf",
-    "parser",
-    "wasm",
-    "webassembly",
-    "browser",
-    "extraction",
-    "markdown"
-  ],
   "files": [
     "edgeparse_wasm_bg.wasm",
     "edgeparse_wasm.js",
-    "edgeparse_wasm.d.ts",
-    "edgeparse_wasm_bg.wasm.d.ts",
-    "README.md",
-    "LICENSE"
+    "edgeparse_wasm.d.ts"
   ],
   "main": "edgeparse_wasm.js",
-  "module": "edgeparse_wasm.js",
   "types": "edgeparse_wasm.d.ts",
-  "exports": {
-    ".": {
-      "import": "./edgeparse_wasm.js",
-      "types": "./edgeparse_wasm.d.ts"
-    }
-  },
   "sideEffects": [
     "./snippets/*"
   ],
+  "keywords": [
+    "pdf",
+    "markdown",
+    "wasm",
+    "parser",
+    "edgeparse"
+  ],
+  "homepage": "https://www.edgeparse.com",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"
+  },
+  "exports": {
+    ".": {
+      "import": "./edgeparse_wasm.js"
+    },
+    "./wasm": {
+      "import": "./edgeparse_wasm_bg.wasm"
+    }
   }
 }

--- a/crates/pdf-cos/Cargo.toml
+++ b/crates/pdf-cos/Cargo.toml
@@ -26,7 +26,7 @@ autoexamples = false
 autotests = false
 autobenches = false
 description = "PDF COS (Carousel Object Structure) parser -- edgeparse fork of lopdf 0.39.0 with f64 Real precision and ICC color support"
-homepage = "https://github.com/edgeparse-project/edgeparse"
+homepage = "https://www.edgeparse.com"
 readme = "README.md"
 keywords = [
     "pdf",

--- a/sdks/node/npm/darwin-arm64/package.json
+++ b/sdks/node/npm/darwin-arm64/package.json
@@ -18,5 +18,5 @@
     "url": "https://github.com/raphaelmansuy/edgeparse.git",
     "directory": "sdks/node/npm/darwin-arm64"
   },
-  "homepage": "https://github.com/raphaelmansuy/edgeparse#readme"
+  "homepage": "https://www.edgeparse.com"
 }

--- a/sdks/node/npm/darwin-x64/package.json
+++ b/sdks/node/npm/darwin-x64/package.json
@@ -18,5 +18,5 @@
     "url": "https://github.com/raphaelmansuy/edgeparse.git",
     "directory": "sdks/node/npm/darwin-x64"
   },
-  "homepage": "https://github.com/raphaelmansuy/edgeparse#readme"
+  "homepage": "https://www.edgeparse.com"
 }

--- a/sdks/node/npm/linux-arm64-gnu/package.json
+++ b/sdks/node/npm/linux-arm64-gnu/package.json
@@ -18,5 +18,5 @@
     "url": "https://github.com/raphaelmansuy/edgeparse.git",
     "directory": "sdks/node/npm/linux-arm64-gnu"
   },
-  "homepage": "https://github.com/raphaelmansuy/edgeparse#readme"
+  "homepage": "https://www.edgeparse.com"
 }

--- a/sdks/node/npm/linux-x64-gnu/package.json
+++ b/sdks/node/npm/linux-x64-gnu/package.json
@@ -18,5 +18,5 @@
     "url": "https://github.com/raphaelmansuy/edgeparse.git",
     "directory": "sdks/node/npm/linux-x64-gnu"
   },
-  "homepage": "https://github.com/raphaelmansuy/edgeparse#readme"
+  "homepage": "https://www.edgeparse.com"
 }

--- a/sdks/node/npm/win32-x64-msvc/package.json
+++ b/sdks/node/npm/win32-x64-msvc/package.json
@@ -18,5 +18,5 @@
     "url": "https://github.com/raphaelmansuy/edgeparse.git",
     "directory": "sdks/node/npm/win32-x64-msvc"
   },
-  "homepage": "https://github.com/raphaelmansuy/edgeparse#readme"
+  "homepage": "https://www.edgeparse.com"
 }

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -31,7 +31,7 @@
     "node": ">=18"
   },
   "license": "Apache-2.0",
-  "homepage": "https://github.com/raphaelmansuy/edgeparse#readme",
+  "homepage": "https://www.edgeparse.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/raphaelmansuy/edgeparse.git",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -25,7 +25,7 @@ keywords = ["pdf", "extraction", "markdown", "rag", "llm"]
 description = "High-performance PDF-to-structured-data extraction — Rust engine, Python interface"
 
 [project.urls]
-Homepage = "https://github.com/raphaelmansuy/edgeparse"
+Homepage = "https://www.edgeparse.com"
 Repository = "https://github.com/raphaelmansuy/edgeparse"
 Documentation = "https://github.com/raphaelmansuy/edgeparse/tree/main/docs"
 


### PR DESCRIPTION
## Summary

Fixes the homepage URL across all published packages and bumps the workspace to **v0.2.5** so the corrected metadata is published to npm, PyPI, and crates.io.

### Root cause
The `edgeparse-wasm@0.2.4` npm package was manually published with `homepage: edgeparse.elitizon.com`. Other SDK packages referenced the GitHub repo URL instead of the product homepage.

### Changes
| File | Change |
|------|--------|
| `Cargo.toml` | `homepage = "https://www.edgeparse.com"` added; version `0.2.4→0.2.5` |
| `crates/pdf-cos/Cargo.toml` | homepage updated |
| `.github/workflows/release-wasm.yml` | `pkg.homepage` corrected |
| `sdks/node/package.json` + 5 platform packages | homepage updated |
| `sdks/python/pyproject.toml` | `Homepage` updated |
| `CHANGELOG.md` | v0.2.5 entry added |
