### PR TITLE
Fix: table cells serialize empty in JSON output

### DIFF
--- a/crates/edgeparse-core/src/output/legacy_json.rs
+++ b/crates/edgeparse-core/src/output/legacy_json.rs
@@ -507,12 +507,62 @@ fn list_to_legacy(list: &PDFList, stem: &str, img_idx: &mut u64) -> Value {
     Value::Object(obj)
 }
 
+/// Build a paragraph node from a border-detected cell's raw text tokens.
+///
+/// Returns `None` when the cell has no textual tokens.
+fn table_cell_tokens_to_paragraph(cell: &TableBorderCell) -> Option<Value> {
+    let text = cell
+        .content
+        .iter()
+        .map(|t| t.base.value.as_str())
+        .collect::<Vec<_>>()
+        .join(" ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if text.is_empty() {
+        return None;
+    }
+
+    let mut para = Map::new();
+    para.insert("type".into(), json!("paragraph"));
+    para.insert("id".into(), json!(next_id()));
+    para.insert("page number".into(), json!(page_num(&cell.bbox)));
+    para.insert("bounding box".into(), bbox_array(&cell.bbox));
+    if let Some(tok) = cell.content.iter().find(|t| !t.base.value.trim().is_empty()) {
+        para.insert(
+            "font".into(),
+            json!(strip_font_prefix(&tok.base.font_name)),
+        );
+        para.insert("font size".into(), json!(tok.base.font_size));
+        para.insert(
+            "text color".into(),
+            json!(format_font_color(&tok.base.font_color)),
+        );
+    }
+    para.insert("content".into(), json!(text));
+    Some(Value::Object(para))
+}
+
 fn table_cell_to_legacy(cell: &TableBorderCell, stem: &str, img_idx: &mut u64) -> Value {
-    let kids: Vec<Value> = cell
+    let mut kids: Vec<Value> = cell
         .contents
         .iter()
         .flat_map(|el| elements_to_legacy(el, stem, img_idx))
         .collect();
+
+    // Fallback: cells populated by the table border-detection path store their
+    // text in `content` (raw TableTokens), not `contents` (semantic elements),
+    // and raw tokens are not emitted by `elements_to_legacy`. Without this, such
+    // cells serialize with empty `kids` even though the text is present and
+    // rendered correctly in the Markdown/HTML/text outputs. Synthesize a
+    // paragraph kid from the token text so JSON matches the other formats.
+    if kids.is_empty() {
+        if let Some(kid) = table_cell_tokens_to_paragraph(cell) {
+            kids.push(kid);
+        }
+    }
+
     let mut obj = Map::new();
     obj.insert("type".into(), json!("table cell"));
     obj.insert("page number".into(), json!(page_num(&cell.bbox)));


### PR DESCRIPTION
## Summary

Border-detected table cells serialize with empty `kids` in JSON output, dropping
all cell text — even though the same tables render correctly in Markdown, HTML,
and text.

## Root cause

`table_cell_to_legacy` builds a cell's `kids` from `cell.contents`
(`Vec<ContentElement>`), and `elements_to_legacy` intentionally skips raw
`TextChunk` / `TextLine` / `TextBlock` elements. But the border-detection
content-assignment path (`table_content_assigner::assign_to_cell`) stores a
cell's text in the *other* field, `cell.content` (`Vec<TableToken>`):

```rust
ContentElement::TextChunk(tc) => {
    cell.content.push(TableToken { base: tc.clone(), token_type: TableTokenType::Text });
}
```

So for any table populated by the border detector, `cell.contents` is empty and
the token text in `cell.content` is never emitted → every cell comes out as
`"kids": []`. Markdown/HTML/text read `cell.content`, so they are unaffected;
only JSON loses the data.

## Fix

In `table_cell_to_legacy`, when `contents` yields no kids, fall back to the
cell's `content` tokens and synthesize a `paragraph` kid from their text. This
mirrors the fallback the same file already uses for list items ("First tries
semantic contents (preferred), then falls back to raw body tokens").

## Before / after

A born-digital 6×2 key-value table (`Input | Value`, `Equity volatility | 55%`,
…) that Markdown renders in full previously produced 12 empty cells in JSON.
After the fix, each cell's `kids` contains a paragraph node with the cell text.

## Changes

- `crates/edgeparse-core/src/output/legacy_json.rs` — `table_cell_tokens_to_paragraph`
  helper and a fallback in `table_cell_to_legacy`.
